### PR TITLE
add metatable handling to ReadOnlyLuaTables

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/LuaTypeManager.java
+++ b/common/src/main/java/org/figuramc/figura/lua/LuaTypeManager.java
@@ -105,6 +105,10 @@ public class LuaTypeManager {
         }
     }
 
+    public Map<Class<?>, LuaTable> getMetatables() {
+        return metatables;
+    }
+
     private final Map<Class<?>, String> namesCache = new HashMap<>();
     public String getTypeName(Class<?> clazz) {
         return namesCache.computeIfAbsent(clazz, someClass -> {

--- a/common/src/main/java/org/figuramc/figura/lua/ReadOnlyLuaTable.java
+++ b/common/src/main/java/org/figuramc/figura/lua/ReadOnlyLuaTable.java
@@ -32,7 +32,7 @@ public class ReadOnlyLuaTable extends LuaTable {
             );
         }
         LuaValue mt = table.getmetatable();
-        if (!(!(mt instanceof LuaTable metaTable) || metaTable instanceof ReadOnlyLuaTable || manager == null || manager.getMetatables().containsValue(metaTable)))
+        if (mt instanceof LuaTable metaTable)
             setMetaTable(metaTable);
     }
 
@@ -46,7 +46,7 @@ public class ReadOnlyLuaTable extends LuaTable {
             seen.put(value, new ReadOnlyLuaTable(value, seen, manager));
         } else if (value.isuserdata()) {
             Object userdata = value.checkuserdata();
-            seen.put(value, LuaValue.userdataOf(userdata instanceof LuaUserdata u ? u.m_instance : userdata));
+            seen.put(value, LuaValue.userdataOf(userdata instanceof LuaUserdata u ? u.m_instance : userdata).setmetatable(value.getmetatable()));
         } else {
             seen.put(value, value);
         }

--- a/common/src/main/java/org/figuramc/figura/lua/ReadOnlyLuaTable.java
+++ b/common/src/main/java/org/figuramc/figura/lua/ReadOnlyLuaTable.java
@@ -1,20 +1,61 @@
 package org.figuramc.figura.lua;
 
 import org.luaj.vm2.LuaTable;
+import org.luaj.vm2.LuaUserdata;
 import org.luaj.vm2.LuaValue;
 import org.luaj.vm2.Varargs;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class ReadOnlyLuaTable extends LuaTable {
-    public ReadOnlyLuaTable(LuaValue table) {
-        presize(table.length(), 0);
-        for (Varargs n = table.next(LuaValue.NIL); !n.arg1().isnil(); n = table
-                .next(n.arg1())) {
-            LuaValue key = n.arg1();
-            LuaValue value = n.arg(2);
-            super.rawset(key, value.istable() ? value == table ? this : new ReadOnlyLuaTable(value) : value);
-        }
+    private final Map<LuaValue, LuaValue> seen;
+    private final LuaTypeManager manager;
+
+    public ReadOnlyLuaTable(LuaValue value) {
+        this(value, null);
     }
+
+    public ReadOnlyLuaTable(LuaValue table, LuaTypeManager manager) {
+        this(table, new HashMap<>(), manager);
+    }
+
+    public ReadOnlyLuaTable(LuaValue table, Map<LuaValue, LuaValue> seen, LuaTypeManager manager) {
+        this.seen = seen;
+        this.manager = manager;
+        seen.put(table, this);
+        presize(table.length(), 0);
+        for (Varargs n = table.next(LuaValue.NIL); !n.arg1().isnil(); n = table.next(n.arg1())) {
+            super.rawset(
+                    wrapIfNecessary(n.arg(1)),
+                    wrapIfNecessary(n.arg(2))
+            );
+        }
+        LuaValue mt = table.getmetatable();
+        if (!(!(mt instanceof LuaTable metaTable) || metaTable instanceof ReadOnlyLuaTable || manager == null || manager.getMetatables().containsValue(metaTable)))
+            setMetaTable(metaTable);
+    }
+
+    private LuaValue wrapIfNecessary(LuaValue value) {
+        if (seen.containsKey(value))
+            return seen.get(value);
+
+        if (value instanceof ReadOnlyLuaTable)
+            seen.put(value, value);
+        else if (value.istable()) {
+            seen.put(value, new ReadOnlyLuaTable(value, seen, manager));
+        } else if (value.isuserdata()) {
+            Object userdata = value.checkuserdata();
+            seen.put(value, LuaValue.userdataOf(userdata instanceof LuaUserdata u ? u.m_instance : userdata));
+        } else {
+            seen.put(value, value);
+        }
+
+        return seen.get(value);
+    }
+
     public LuaValue setmetatable(LuaValue metatable) { return error("table is read-only"); }
+    public void setMetaTable(LuaValue metaTable) { super.setmetatable(metaTable); }
     public void set(int key, LuaValue value) { error("table is read-only"); }
     public void rawset(int key, LuaValue value) { error("table is read-only"); }
     public void rawset(LuaValue key, LuaValue value) { error("table is read-only"); }

--- a/common/src/main/java/org/figuramc/figura/lua/api/world/WorldAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/world/WorldAPI.java
@@ -155,8 +155,6 @@ public class WorldAPI {
     public static int getRedstonePower(Object x, Double y, Double z) {
         FiguraVec3 pos = LuaUtils.parseVec3("getRedstonePower", x, y, z);
         BlockPos blockPos = pos.asBlockPos();
-        if (getCurrentWorld().getChunkAt(blockPos) == null)
-            return 0;
         return getCurrentWorld().getBestNeighborSignal(blockPos);
     }
 
@@ -177,8 +175,6 @@ public class WorldAPI {
     public static int getStrongRedstonePower(Object x, Double y, Double z) {
         FiguraVec3 pos = LuaUtils.parseVec3("getStrongRedstonePower", x, y, z);
         BlockPos blockPos = pos.asBlockPos();
-        if (getCurrentWorld().getChunkAt(blockPos) == null)
-            return 0;
         return getCurrentWorld().getDirectSignalTo(blockPos);
     }
 
@@ -261,8 +257,6 @@ public class WorldAPI {
         FiguraVec3 pos = LuaUtils.parseVec3("getLightLevel", x, y, z);
         BlockPos blockPos = pos.asBlockPos();
         Level world = getCurrentWorld();
-        if (world.getChunkAt(blockPos) == null)
-            return null;
         world.updateSkyBrightness();
         return world.getLightEngine().getRawBrightness(blockPos, world.getSkyDarken());
     }
@@ -285,8 +279,6 @@ public class WorldAPI {
         FiguraVec3 pos = LuaUtils.parseVec3("getSkyLightLevel", x, y, z);
         BlockPos blockPos = pos.asBlockPos();
         Level world = getCurrentWorld();
-        if (world.getChunkAt(blockPos) == null)
-            return null;
         return world.getBrightness(LightLayer.SKY, blockPos);
     }
 
@@ -308,8 +300,6 @@ public class WorldAPI {
         FiguraVec3 pos = LuaUtils.parseVec3("getBlockLightLevel", x, y, z);
         BlockPos blockPos = pos.asBlockPos();
         Level world = getCurrentWorld();
-        if (world.getChunkAt(blockPos) == null)
-            return null;
         return world.getBrightness(LightLayer.BLOCK, blockPos);
     }
 
@@ -331,8 +321,6 @@ public class WorldAPI {
         FiguraVec3 pos = LuaUtils.parseVec3("isOpenSky", x, y, z);
         BlockPos blockPos = pos.asBlockPos();
         Level world = getCurrentWorld();
-        if (world.getChunkAt(blockPos) == null)
-            return null;
         return world.canSeeSky(blockPos);
     }
 
@@ -369,6 +357,7 @@ public class WorldAPI {
     }
 
     // @LuaWhitelist
+    @SuppressWarnings("unused")
     public HashMap<String, Object> raycastBlock(boolean fluid, Object x, Object y, Double z, Object w, Double t, Double h) {
         FiguraVec3 start, end;
 
@@ -390,6 +379,7 @@ public class WorldAPI {
     }
 
     // @LuaWhitelist
+    @SuppressWarnings("unused")
     public HashMap<String, Object> raycastEntity(Object x, Object y, Double z, Object w, Double t, Double h) {
         FiguraVec3 start, end;
 
@@ -414,8 +404,13 @@ public class WorldAPI {
     public static Map<String, LuaTable> avatarVars() {
         HashMap<String, LuaTable> varList = new HashMap<>();
         for (Avatar avatar : AvatarManager.getLoadedAvatars()) {
-            LuaTable tbl = avatar.luaRuntime == null ? new LuaTable() : avatar.luaRuntime.avatar_meta.storedStuff;
-            varList.put(avatar.owner.toString(), new ReadOnlyLuaTable(tbl));
+            LuaTable table;
+            if (avatar.luaRuntime == null) {
+                table = new ReadOnlyLuaTable(new LuaTable());
+            } else {
+                table = new ReadOnlyLuaTable(avatar.luaRuntime.avatar_meta.storedStuff, avatar.luaRuntime.typeManager);
+            }
+            varList.put(avatar.owner.toString(), table);
         }
         return varList;
     }


### PR DESCRIPTION
makes AvatarAPI not ignore metatables
probably one change necessary would be making ReadOnlyLuaTable not strip userdata metatables as currently it breaks things like vectors, that are retreived from player's avatar variables