### PR TITLE
Armor pivot support

### DIFF
--- a/common/src/main/java/org/figuramc/figura/exporters/BlockBenchModel.java
+++ b/common/src/main/java/org/figuramc/figura/exporters/BlockBenchModel.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import org.figuramc.figura.math.vector.FiguraVec3;
 import org.figuramc.figura.math.vector.FiguraVec4;
+import org.figuramc.figura.model.ParentType;
 
 import java.util.ArrayList;
 import java.util.UUID;
@@ -55,6 +56,10 @@ public class BlockBenchModel {
         Group g = new Group(name, pivot);
         addElement(g, parent);
         return g;
+    }
+
+    public Group addGroup(ParentType type, FiguraVec3 pivot, Group parent) {
+        return addGroup(type.name(), pivot, parent);
     }
 
     public Cube addCube(FiguraVec3 position, FiguraVec3 size, Group parent) {

--- a/common/src/main/java/org/figuramc/figura/gui/widgets/lists/AvatarWizardList.java
+++ b/common/src/main/java/org/figuramc/figura/gui/widgets/lists/AvatarWizardList.java
@@ -15,11 +15,14 @@ import org.figuramc.figura.FiguraMod;
 import org.figuramc.figura.utils.FiguraText;
 import org.figuramc.figura.utils.ui.UIHelper;
 import org.figuramc.figura.wizards.AvatarWizard;
+import org.figuramc.figura.wizards.WizardEntry;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.figuramc.figura.wizards.WizardEntry.Type.CATEGORY;
 
 public class AvatarWizardList extends AbstractList {
 
@@ -119,15 +122,15 @@ public class AvatarWizardList extends AbstractList {
         Component lastName = Component.empty();
         List<GuiEventListener> lastList = new ArrayList<>();
 
-        for (AvatarWizard.WizardEntry value : AvatarWizard.WizardEntry.values()) {
-            switch (value.getType()) {
+        for (WizardEntry value : WizardEntry.all()) {
+            switch (value.type) {
                 case CATEGORY -> {
                     if (!lastList.isEmpty()) {
                         map.put(lastName, lastList);
                         children.addAll(lastList);
                     }
 
-                    lastName = FiguraText.of("gui.avatar_wizard." + value.name().toLowerCase());
+                    lastName = FiguraText.of("gui.avatar_wizard." + value.name.toLowerCase());
                     lastList = new ArrayList<>();
                 }
                 case TEXT -> lastList.add(new WizardInputBox(x, width, this, value));
@@ -142,14 +145,14 @@ public class AvatarWizardList extends AbstractList {
     private static class WizardInputBox extends TextField {
 
         private final AvatarWizardList parent;
-        private final AvatarWizard.WizardEntry entry;
+        private final WizardEntry entry;
         private final Component name;
 
-        public WizardInputBox(int x, int width, AvatarWizardList parent, AvatarWizard.WizardEntry entry) {
+        public WizardInputBox(int x, int width, AvatarWizardList parent, WizardEntry entry) {
             super(x, 0, width, 20, HintType.ANY, s -> parent.wizard.changeEntry(entry, s));
             this.parent = parent;
             this.entry = entry;
-            this.name = FiguraText.of("gui.avatar_wizard." + entry.name().toLowerCase());
+            this.name = FiguraText.of("gui.avatar_wizard." + entry.name.toLowerCase());
             this.getField().setValue(String.valueOf(parent.wizard.getEntry(entry, "")));
         }
 
@@ -174,10 +177,10 @@ public class AvatarWizardList extends AbstractList {
     private static class WizardToggleButton extends SwitchButton {
 
         private final AvatarWizardList parent;
-        private final AvatarWizard.WizardEntry entry;
+        private final WizardEntry entry;
 
-        public WizardToggleButton(int x, int width, AvatarWizardList parent, AvatarWizard.WizardEntry entry) {
-            super(x, 0, width, 20, FiguraText.of("gui.avatar_wizard." + entry.name().toLowerCase()), false);
+        public WizardToggleButton(int x, int width, AvatarWizardList parent, WizardEntry entry) {
+            super(x, 0, width, 20, FiguraText.of("gui.avatar_wizard." + entry.name.toLowerCase()), false);
             this.parent = parent;
             this.entry = entry;
             this.setToggled((boolean) parent.wizard.getEntry(entry, false));

--- a/common/src/main/java/org/figuramc/figura/lua/api/vanilla_model/VanillaModelAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/vanilla_model/VanillaModelAPI.java
@@ -187,82 +187,88 @@ public class VanillaModelAPI {
     @LuaFieldDoc("vanilla_model.parrots")
     public final VanillaGroupPart PARROTS;
 
+    // Adds a VanillaPart to the list of all parts. Used for indexing
+    private <TPart extends VanillaPart>TPart addPart(TPart part) {
+        allParts.put(part.name, part);
+        return part;
+    }
+
     public VanillaModelAPI(Avatar owner) {
         // -- body -- //
 
-        HEAD = new VanillaModelPart(owner, "HEAD", ParentType.Head, VanillaModelProvider.HEAD.func);
-        BODY = new VanillaModelPart(owner, "BODY", ParentType.Body, VanillaModelProvider.BODY.func);
-        LEFT_ARM = new VanillaModelPart(owner, "LEFT_ARM", ParentType.LeftArm, VanillaModelProvider.LEFT_ARM.func);
-        RIGHT_ARM = new VanillaModelPart(owner, "RIGHT_ARM", ParentType.RightArm, VanillaModelProvider.RIGHT_ARM.func);
-        LEFT_LEG = new VanillaModelPart(owner, "LEFT_LEG", ParentType.LeftLeg, VanillaModelProvider.LEFT_LEG.func);
-        RIGHT_LEG = new VanillaModelPart(owner, "RIGHT_LEG", ParentType.RightLeg, VanillaModelProvider.RIGHT_LEG.func);
+        HEAD = addPart(new VanillaModelPart(owner, "HEAD", ParentType.Head, VanillaModelProvider.HEAD.func));
+        BODY = addPart(new VanillaModelPart(owner, "BODY", ParentType.Body, VanillaModelProvider.BODY.func));
+        LEFT_ARM = addPart(new VanillaModelPart(owner, "LEFT_ARM", ParentType.LeftArm, VanillaModelProvider.LEFT_ARM.func));
+        RIGHT_ARM = addPart(new VanillaModelPart(owner, "RIGHT_ARM", ParentType.RightArm, VanillaModelProvider.RIGHT_ARM.func));
+        LEFT_LEG = addPart(new VanillaModelPart(owner, "LEFT_LEG", ParentType.LeftLeg, VanillaModelProvider.LEFT_LEG.func));
+        RIGHT_LEG = addPart(new VanillaModelPart(owner, "RIGHT_LEG", ParentType.RightLeg, VanillaModelProvider.RIGHT_LEG.func));
 
-        HAT = new VanillaModelPart(owner, "HAT", ParentType.Head, VanillaModelProvider.HAT.func);
-        JACKET = new VanillaModelPart(owner, "JACKET", ParentType.Body, VanillaModelProvider.JACKET.func);
-        LEFT_SLEEVE = new VanillaModelPart(owner, "LEFT_SLEEVE", ParentType.LeftArm, VanillaModelProvider.LEFT_SLEEVE.func);
-        RIGHT_SLEEVE = new VanillaModelPart(owner, "RIGHT_SLEEVE", ParentType.RightArm, VanillaModelProvider.RIGHT_SLEEVE.func);
-        LEFT_PANTS = new VanillaModelPart(owner, "LEFT_PANTS", ParentType.LeftLeg, VanillaModelProvider.LEFT_PANTS.func);
-        RIGHT_PANTS = new VanillaModelPart(owner, "RIGHT_PANTS", ParentType.RightLeg, VanillaModelProvider.RIGHT_PANTS.func);
+        HAT = addPart(new VanillaModelPart(owner, "HAT", ParentType.Head, VanillaModelProvider.HAT.func));
+        JACKET = addPart(new VanillaModelPart(owner, "JACKET", ParentType.Body, VanillaModelProvider.JACKET.func));
+        LEFT_SLEEVE = addPart(new VanillaModelPart(owner, "LEFT_SLEEVE", ParentType.LeftArm, VanillaModelProvider.LEFT_SLEEVE.func));
+        RIGHT_SLEEVE = addPart(new VanillaModelPart(owner, "RIGHT_SLEEVE", ParentType.RightArm, VanillaModelProvider.RIGHT_SLEEVE.func));
+        LEFT_PANTS = addPart(new VanillaModelPart(owner, "LEFT_PANTS", ParentType.LeftLeg, VanillaModelProvider.LEFT_PANTS.func));
+        RIGHT_PANTS = addPart(new VanillaModelPart(owner, "RIGHT_PANTS", ParentType.RightLeg, VanillaModelProvider.RIGHT_PANTS.func));
 
         // -- cape -- //
 
-        CAPE_MODEL = new VanillaModelPart(owner, "CAPE_MODEL", ParentType.Cape, VanillaModelProvider.CAPE.func);
-        FAKE_CAPE = new VanillaModelPart(owner, "FAKE_CAPE", ParentType.Cape, VanillaModelProvider.FAKE_CAPE.func);
+        CAPE_MODEL = addPart(new VanillaModelPart(owner, "CAPE_MODEL", ParentType.Cape, VanillaModelProvider.CAPE.func));
+        FAKE_CAPE = addPart(new VanillaModelPart(owner, "FAKE_CAPE", ParentType.Cape, VanillaModelProvider.FAKE_CAPE.func));
 
         // -- armor -- //
 
-        HELMET_ITEM = new VanillaModelPart(owner, "HELMET_ITEM", ParentType.Head, null);
+        HELMET_ITEM = addPart(new VanillaModelPart(owner, "HELMET_ITEM", ParentType.Head, null));
 
-        HELMET_HEAD = new VanillaModelPart(owner, "HELMET_HEAD", ParentType.Head, VanillaModelProvider.HEAD.func);
-        HELMET_HAT = new VanillaModelPart(owner, "HELMET_HAT", ParentType.Head, VanillaModelProvider.HAT.func);
+        HELMET_HEAD = addPart(new VanillaModelPart(owner, "HELMET_HEAD", ParentType.Head, VanillaModelProvider.HEAD.func));
+        HELMET_HAT = addPart(new VanillaModelPart(owner, "HELMET_HAT", ParentType.Head, VanillaModelProvider.HAT.func));
 
-        CHESTPLATE_BODY = new VanillaModelPart(owner, "CHESTPLATE_BODY", ParentType.Body, VanillaModelProvider.BODY.func);
-        CHESTPLATE_LEFT_ARM = new VanillaModelPart(owner, "CHESTPLATE_LEFT_ARM", ParentType.LeftArm, VanillaModelProvider.LEFT_ARM.func);
-        CHESTPLATE_RIGHT_ARM = new VanillaModelPart(owner, "CHESTPLATE_RIGHT_ARM", ParentType.RightArm, VanillaModelProvider.RIGHT_ARM.func);
+        CHESTPLATE_BODY = addPart(new VanillaModelPart(owner, "CHESTPLATE_BODY", ParentType.Body, VanillaModelProvider.BODY.func));
+        CHESTPLATE_LEFT_ARM = addPart(new VanillaModelPart(owner, "CHESTPLATE_LEFT_ARM", ParentType.LeftArm, VanillaModelProvider.LEFT_ARM.func));
+        CHESTPLATE_RIGHT_ARM = addPart(new VanillaModelPart(owner, "CHESTPLATE_RIGHT_ARM", ParentType.RightArm, VanillaModelProvider.RIGHT_ARM.func));
 
-        LEGGINGS_BODY = new VanillaModelPart(owner, "LEGGINGS_BODY", ParentType.Body, VanillaModelProvider.BODY.func);
-        LEGGINGS_LEFT_LEG = new VanillaModelPart(owner, "LEGGINGS_LEFT_LEG", ParentType.LeftLeg, VanillaModelProvider.LEFT_LEG.func);
-        LEGGINGS_RIGHT_LEG = new VanillaModelPart(owner, "LEGGINGS_RIGHT_LEG", ParentType.RightLeg, VanillaModelProvider.RIGHT_LEG.func);
+        LEGGINGS_BODY = addPart(new VanillaModelPart(owner, "LEGGINGS_BODY", ParentType.Body, VanillaModelProvider.BODY.func));
+        LEGGINGS_LEFT_LEG = addPart(new VanillaModelPart(owner, "LEGGINGS_LEFT_LEG", ParentType.LeftLeg, VanillaModelProvider.LEFT_LEG.func));
+        LEGGINGS_RIGHT_LEG = addPart(new VanillaModelPart(owner, "LEGGINGS_RIGHT_LEG", ParentType.RightLeg, VanillaModelProvider.RIGHT_LEG.func));
 
-        BOOTS_LEFT_LEG = new VanillaModelPart(owner, "BOOTS_LEFT_LEG", ParentType.LeftLeg, VanillaModelProvider.LEFT_LEG.func);
-        BOOTS_RIGHT_LEG = new VanillaModelPart(owner, "BOOTS_RIGHT_LEG", ParentType.RightLeg, VanillaModelProvider.RIGHT_LEG.func);
+        BOOTS_LEFT_LEG = addPart(new VanillaModelPart(owner, "BOOTS_LEFT_LEG", ParentType.LeftLeg, VanillaModelProvider.LEFT_LEG.func));
+        BOOTS_RIGHT_LEG = addPart(new VanillaModelPart(owner, "BOOTS_RIGHT_LEG", ParentType.RightLeg, VanillaModelProvider.RIGHT_LEG.func));
 
         // -- elytra -- //
 
-        LEFT_ELYTRA = new VanillaModelPart(owner, "LEFT_ELYTRA", ParentType.LeftElytra, VanillaModelProvider.LEFT_ELYTRON.func);
-        RIGHT_ELYTRA = new VanillaModelPart(owner, "RIGHT_ELYTRA", ParentType.RightElytra, VanillaModelProvider.RIGHT_ELYTRON.func);
+        LEFT_ELYTRA = addPart(new VanillaModelPart(owner, "LEFT_ELYTRA", ParentType.LeftElytra, VanillaModelProvider.LEFT_ELYTRON.func));
+        RIGHT_ELYTRA = addPart(new VanillaModelPart(owner, "RIGHT_ELYTRA", ParentType.RightElytra, VanillaModelProvider.RIGHT_ELYTRON.func));
 
         // -- held items -- //
 
-        LEFT_ITEM = new VanillaModelPart(owner, "LEFT_ITEM", ParentType.LeftArm, null);
-        RIGHT_ITEM = new VanillaModelPart(owner, "RIGHT_ITEM", ParentType.RightArm, null);
+        LEFT_ITEM = addPart(new VanillaModelPart(owner, "LEFT_ITEM", ParentType.LeftArm, null));
+        RIGHT_ITEM = addPart(new VanillaModelPart(owner, "RIGHT_ITEM", ParentType.RightArm, null));
 
         // -- parrots -- //
 
-        LEFT_PARROT = new VanillaModelPart(owner, "LEFT_PARROT", ParentType.Body, null);
-        RIGHT_PARROT = new VanillaModelPart(owner, "RIGHT_PARROT", ParentType.Body, null);
+        LEFT_PARROT = addPart(new VanillaModelPart(owner, "LEFT_PARROT", ParentType.Body, null));
+        RIGHT_PARROT = addPart(new VanillaModelPart(owner, "RIGHT_PARROT", ParentType.Body, null));
 
 
         // -- groups -- //
 
 
-        INNER_LAYER = new VanillaGroupPart(owner, "INNER_LAYER", HEAD, BODY, LEFT_ARM, RIGHT_ARM, LEFT_LEG, RIGHT_LEG);
-        OUTER_LAYER = new VanillaGroupPart(owner, "OUTER_LAYER", HAT, JACKET, LEFT_SLEEVE, RIGHT_SLEEVE, LEFT_PANTS, RIGHT_PANTS);
-        PLAYER = new VanillaGroupPart(owner, "PLAYER", INNER_LAYER, OUTER_LAYER);
+        INNER_LAYER = addPart(new VanillaGroupPart(owner, "INNER_LAYER", HEAD, BODY, LEFT_ARM, RIGHT_ARM, LEFT_LEG, RIGHT_LEG));
+        OUTER_LAYER = addPart(new VanillaGroupPart(owner, "OUTER_LAYER", HAT, JACKET, LEFT_SLEEVE, RIGHT_SLEEVE, LEFT_PANTS, RIGHT_PANTS));
+        PLAYER = addPart(new VanillaGroupPart(owner, "PLAYER", INNER_LAYER, OUTER_LAYER));
 
-        CAPE = new VanillaGroupPart(owner, "CAPE", CAPE_MODEL, FAKE_CAPE);
+        CAPE = addPart(new VanillaGroupPart(owner, "CAPE", CAPE_MODEL, FAKE_CAPE));
 
-        HELMET = new VanillaGroupPart(owner, "HELMET", HELMET_ITEM, HELMET_HEAD, HELMET_HAT);
-        CHESTPLATE = new VanillaGroupPart(owner, "CHESTPLATE", CHESTPLATE_BODY, CHESTPLATE_LEFT_ARM, CHESTPLATE_RIGHT_ARM);
-        LEGGINGS = new VanillaGroupPart(owner, "LEGGINGS", LEGGINGS_BODY, LEGGINGS_LEFT_LEG, LEGGINGS_RIGHT_LEG);
-        BOOTS = new VanillaGroupPart(owner, "BOOTS", BOOTS_LEFT_LEG, BOOTS_RIGHT_LEG);
-        ARMOR = new VanillaGroupPart(owner, "ARMOR", HELMET, CHESTPLATE, LEGGINGS, BOOTS);
+        HELMET = addPart(new VanillaGroupPart(owner, "HELMET", HELMET_ITEM, HELMET_HEAD, HELMET_HAT));
+        CHESTPLATE = addPart(new VanillaGroupPart(owner, "CHESTPLATE", CHESTPLATE_BODY, CHESTPLATE_LEFT_ARM, CHESTPLATE_RIGHT_ARM));
+        LEGGINGS = addPart(new VanillaGroupPart(owner, "LEGGINGS", LEGGINGS_BODY, LEGGINGS_LEFT_LEG, LEGGINGS_RIGHT_LEG));
+        BOOTS = addPart(new VanillaGroupPart(owner, "BOOTS", BOOTS_LEFT_LEG, BOOTS_RIGHT_LEG));
+        ARMOR = addPart(new VanillaGroupPart(owner, "ARMOR", HELMET, CHESTPLATE, LEGGINGS, BOOTS));
 
-        ELYTRA = new VanillaGroupPart(owner, "ELYTRA", LEFT_ELYTRA, RIGHT_ELYTRA);
+        ELYTRA = addPart(new VanillaGroupPart(owner, "ELYTRA", LEFT_ELYTRA, RIGHT_ELYTRA));
 
-        HELD_ITEMS = new VanillaGroupPart(owner, "HELD_ITEMS", LEFT_ITEM, RIGHT_ITEM);
+        HELD_ITEMS = addPart(new VanillaGroupPart(owner, "HELD_ITEMS", LEFT_ITEM, RIGHT_ITEM));
 
-        PARROTS = new VanillaGroupPart(owner, "PARROTS", LEFT_PARROT, RIGHT_PARROT);
+        PARROTS = addPart(new VanillaGroupPart(owner, "PARROTS", LEFT_PARROT, RIGHT_PARROT));
 
         List<VanillaGroupPart> groups = new ArrayList<>() {{
             add(PLAYER);
@@ -275,36 +281,32 @@ public class VanillaModelAPI {
 
 
         // -- modded parts -- //
-
-
         for (FiguraVanillaPart entrypoint : ENTRYPOINTS) {
             //prepare group
             List<VanillaModelPart> parts = new ArrayList<>();
             String ID = entrypoint.getID().toUpperCase();
 
-            //get parts
+            // Iterate over parts added by the current entrypoint
             for (Pair<String, Function<EntityModel<?>, ModelPart>> part : entrypoint.getParts()) {
                 String name = ID + "_" + part.getFirst().toUpperCase();
                 VanillaModelPart model = new VanillaModelPart(owner, name, ParentType.None, part.getSecond());
-                moddedParts.put(name, model);
+                allParts.put(name, model);
                 parts.add(model);
             }
 
             //add to group list
             VanillaGroupPart group = new VanillaGroupPart(owner, ID, parts.toArray(new VanillaModelPart[0]));
-            moddedParts.put(ID, group);
+            allParts.put(ID, group);
             groups.add(group);
         }
 
 
         // -- all -- //
-
-
-        ALL = new VanillaGroupPart(owner, "ALL", groups.toArray(new VanillaGroupPart[0]));
+        ALL = addPart(new VanillaGroupPart(owner, "ALL", groups.toArray(new VanillaGroupPart[0])));
     }
 
     private static final List<FiguraVanillaPart> ENTRYPOINTS = new ArrayList<>();
-    private final Map<String, VanillaPart> moddedParts = new HashMap<>();
+    private final Map<String, VanillaPart> allParts = new HashMap<>();
 
     public static void initEntryPoints(Set<FiguraVanillaPart> set) {
         ENTRYPOINTS.addAll(set);
@@ -313,55 +315,7 @@ public class VanillaModelAPI {
     @LuaWhitelist
     public Object __index(String key) {
         if (key == null) return null;
-        String name = key.toUpperCase();
-        VanillaPart part = switch (name) {
-            case "HEAD" -> HEAD;
-            case "BODY" -> BODY;
-            case "LEFT_ARM" -> LEFT_ARM;
-            case "RIGHT_ARM" -> RIGHT_ARM;
-            case "LEFT_LEG" -> LEFT_LEG;
-            case "RIGHT_LEG" -> RIGHT_LEG;
-            case "HAT" -> HAT;
-            case "JACKET" -> JACKET;
-            case "LEFT_SLEEVE" -> LEFT_SLEEVE;
-            case "RIGHT_SLEEVE" -> RIGHT_SLEEVE;
-            case "LEFT_PANTS" -> LEFT_PANTS;
-            case "RIGHT_PANTS" -> RIGHT_PANTS;
-            case "CAPE_MODEL" -> CAPE_MODEL;
-            case "FAKE_CAPE" -> FAKE_CAPE;
-            case "HELMET_ITEM" -> HELMET_ITEM;
-            case "HELMET_HEAD" -> HELMET_HEAD;
-            case "HELMET_HAT" -> HELMET_HAT;
-            case "CHESTPLATE_BODY" -> CHESTPLATE_BODY;
-            case "CHESTPLATE_LEFT_ARM" -> CHESTPLATE_LEFT_ARM;
-            case "CHESTPLATE_RIGHT_ARM" -> CHESTPLATE_RIGHT_ARM;
-            case "LEGGINGS_BODY" -> LEGGINGS_BODY;
-            case "LEGGINGS_LEFT_LEG" -> LEGGINGS_LEFT_LEG;
-            case "LEGGINGS_RIGHT_LEG" -> LEGGINGS_RIGHT_LEG;
-            case "BOOTS_LEFT_LEG" -> BOOTS_LEFT_LEG;
-            case "BOOTS_RIGHT_LEG" -> BOOTS_RIGHT_LEG;
-            case "LEFT_ELYTRA" -> LEFT_ELYTRA;
-            case "RIGHT_ELYTRA" -> RIGHT_ELYTRA;
-            case "LEFT_ITEM" -> LEFT_ITEM;
-            case "RIGHT_ITEM" -> RIGHT_ITEM;
-            case "LEFT_PARROT" -> LEFT_PARROT;
-            case "RIGHT_PARROT" -> RIGHT_PARROT;
-            case "INNER_LAYER" -> INNER_LAYER;
-            case "OUTER_LAYER" -> OUTER_LAYER;
-            case "PLAYER" -> PLAYER;
-            case "CAPE" -> CAPE;
-            case "HELMET" -> HELMET;
-            case "CHESTPLATE" -> CHESTPLATE;
-            case "LEGGINGS" -> LEGGINGS;
-            case "BOOTS" -> BOOTS;
-            case "ARMOR" -> ARMOR;
-            case "ELYTRA" -> ELYTRA;
-            case "HELD_ITEMS" -> HELD_ITEMS;
-            case "PARROTS" -> PARROTS;
-            case "ALL" -> ALL;
-            default -> null;
-        };
-        return part != null ? part : moddedParts.get(name);
+        return allParts.getOrDefault(key.toUpperCase(), null);
     }
 
     @Override

--- a/common/src/main/java/org/figuramc/figura/mixin/render/layers/HumanoidArmorLayerAccessor.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/layers/HumanoidArmorLayerAccessor.java
@@ -1,0 +1,39 @@
+package org.figuramc.figura.mixin.render.layers;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.model.HumanoidModel;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ArmorItem;
+import net.minecraft.world.item.ArmorMaterial;
+import net.minecraft.world.item.armortrim.ArmorTrim;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Intrinsic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(HumanoidArmorLayer.class)
+public interface HumanoidArmorLayerAccessor<T extends LivingEntity, M extends HumanoidModel<T>, A extends HumanoidModel<T>> {
+    @Intrinsic
+    @Invoker("renderModel")
+    void renderModel(PoseStack matrices, MultiBufferSource vertexConsumers, int light, ArmorItem item, A model, boolean usesSecondLayer, float red, float green, float blue, @Nullable String overlay);
+
+    @Intrinsic
+    @Invoker("renderTrim")
+    void renderTrim(ArmorMaterial material, PoseStack matrices, MultiBufferSource vertexConsumers, int light, ArmorTrim permutation, A model, boolean bl);
+
+    @Intrinsic
+    @Invoker("renderGlint")
+    void renderGlint(PoseStack matrices, MultiBufferSource vertexConsumers, int light, A model);
+
+    @Intrinsic
+    @Invoker("usesInnerModel")
+    boolean usesInnerModel(EquipmentSlot armorSlot);
+
+    @Intrinsic
+    @Invoker("getArmorLocation")
+    ResourceLocation getArmorLocation(ArmorItem item, boolean legs, @Nullable String overlay);
+}

--- a/common/src/main/java/org/figuramc/figura/mixin/render/layers/HumanoidArmorLayerMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/layers/HumanoidArmorLayerMixin.java
@@ -1,57 +1,231 @@
 package org.figuramc.figura.mixin.render.layers;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.math.Axis;
 import net.minecraft.client.model.HumanoidModel;
+import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.entity.RenderLayerParent;
 import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
 import net.minecraft.client.renderer.entity.layers.RenderLayer;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.client.renderer.texture.TextureAtlas;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
-import org.figuramc.figura.lua.api.vanilla_model.VanillaPart;
+import net.minecraft.world.item.ArmorItem;
+import net.minecraft.world.item.DyeableArmorItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.armortrim.ArmorTrim;
 import org.figuramc.figura.avatar.Avatar;
 import org.figuramc.figura.avatar.AvatarManager;
+import org.figuramc.figura.lua.api.vanilla_model.VanillaPart;
+import org.figuramc.figura.model.ParentType;
+import org.figuramc.figura.utils.FiguraArmorPartRenderer;
 import org.figuramc.figura.utils.RenderUtils;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(HumanoidArmorLayer.class)
-public abstract class HumanoidArmorLayerMixin<T extends LivingEntity, M extends HumanoidModel<T>, A extends HumanoidModel<T>> extends RenderLayer<T, M> {
+public abstract class HumanoidArmorLayerMixin<T extends LivingEntity, M extends HumanoidModel<T>, A extends HumanoidModel<T>> extends RenderLayer<T, M> implements HumanoidArmorLayerAccessor<T, M, A> {
+
+    @Shadow
+    protected abstract A getArmorModel(EquipmentSlot slot);
+
+    @Shadow
+    @Final
+    private TextureAtlas armorTrimAtlas;
+
+    @Shadow
+    protected abstract void renderArmorPiece(PoseStack matrices, MultiBufferSource vertexConsumers, T entity, EquipmentSlot armorSlot, int light, A model);
+
+    @Unique
+    private Avatar avatar;
 
     public HumanoidArmorLayerMixin(RenderLayerParent<T, M> context) {
         super(context);
     }
 
-    @Unique
-    private Avatar avatar;
+    @Inject(at = @At("HEAD"), method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V", cancellable = true)
+    public void onRender(PoseStack vanillaPoseStack, MultiBufferSource multiBufferSource, int light, T livingEntity, float f, float g, float h, float j, float k, float l, CallbackInfo ci) {
+        avatar = AvatarManager.getAvatar(livingEntity);
+        if (avatar == null) return;
 
-    @Inject(at = @At("HEAD"), method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V")
-    public void onRender(PoseStack poseStack, MultiBufferSource multiBufferSource, int i, T livingEntity, float f, float g, float h, float j, float k, float l, CallbackInfo ci) {
-         avatar = AvatarManager.getAvatar(livingEntity);
+        figura$tryRenderArmorPart(EquipmentSlot.HEAD, this::figura$helmetRenderer, vanillaPoseStack, livingEntity, multiBufferSource, light, ParentType.HelmetPivot);
+        figura$tryRenderArmorPart(EquipmentSlot.CHEST, this::figura$chestplateRenderer, vanillaPoseStack, livingEntity, multiBufferSource, light, ParentType.LeftShoulderPivot, ParentType.ChestplatePivot, ParentType.RightShoulderPivot);
+        figura$tryRenderArmorPart(EquipmentSlot.LEGS, this::figura$leggingsRenderer, vanillaPoseStack, livingEntity, multiBufferSource, light, ParentType.LeftLeggingPivot, ParentType.RightLeggingPivot, ParentType.LeggingsPivot);
+        figura$tryRenderArmorPart(EquipmentSlot.FEET, this::figura$bootsRenderer, vanillaPoseStack, livingEntity, multiBufferSource, light, ParentType.LeftBootPivot, ParentType.RightBootPivot);
+
+        ci.cancel();
+    }
+
+    @Unique
+    private void figura$tryRenderArmorPart(EquipmentSlot slot, FiguraArmorPartRenderer<T, M, A> renderer, PoseStack vanillaPoseStack, T entity, MultiBufferSource vertexConsumers, int light, ParentType... parentTypes) {
+        ItemStack itemStack = entity.getItemBySlot(slot);
+
+        // Make sure the item in the equipment slot is actually a piece of armor
+        if ((itemStack.getItem() instanceof ArmorItem armorItem && armorItem.getEquipmentSlot() == slot)) {
+            A armorModel = getArmorModel(slot);
+            boolean allFailed = true;
+
+            // Go through each parent type needed to render the current piece of armor
+            for (ParentType parentType : parentTypes) {
+
+                // Try to render the pivot part
+                boolean renderedPivot = avatar.pivotPartRender(parentType, stack -> {
+                    stack.pushPose();
+                    figura$prepareArmorRender(stack);
+                    renderer.renderArmorPart(stack, vertexConsumers, light, armorModel, entity, itemStack, slot, armorItem, parentType);
+                    stack.popPose();
+                });
+
+                if (renderedPivot) {
+                    allFailed = false;
+                }
+            }
+
+            // As a fallback, render armor the vanilla way
+            if (allFailed) {
+                renderArmorPiece(vanillaPoseStack, vertexConsumers, entity, slot, light, armorModel);
+            }
+        }
+
+    }
+
+    // Prepare the transformations for rendering armor on the avatar
+    @Unique
+    private void figura$prepareArmorRender(PoseStack stack) {
+        stack.scale(16, 16, 16);
+        stack.mulPose(Axis.XP.rotationDegrees(180f));
+        stack.mulPose(Axis.YP.rotationDegrees(180f));
+    }
+
+    @Unique
+    private void figura$helmetRenderer(PoseStack poseStack, MultiBufferSource vertexConsumers, int light, A model, T entity, ItemStack itemStack, EquipmentSlot armorSlot, ArmorItem armorItem, ParentType parentType) {
+        if (parentType == ParentType.HelmetPivot) {
+            figura$renderArmorPart(model.head, poseStack, vertexConsumers, light, entity, itemStack, armorSlot, armorItem);
+        }
+    }
+
+    @Unique
+    private void figura$chestplateRenderer(PoseStack poseStack, MultiBufferSource vertexConsumers, int light, A model, T entity, ItemStack itemStack, EquipmentSlot armorSlot, ArmorItem armorItem, ParentType parentType) {
+        if (parentType == ParentType.ChestplatePivot) {
+            figura$renderArmorPart(model.body, poseStack, vertexConsumers, light, entity, itemStack, armorSlot, armorItem);
+        }
+
+        if (parentType == ParentType.LeftShoulderPivot) {
+            poseStack.pushPose();
+            poseStack.translate(-6 / 16f, 0f, 0f);
+            figura$renderArmorPart(model.leftArm, poseStack, vertexConsumers, light, entity, itemStack, armorSlot, armorItem);
+            poseStack.popPose();
+        }
+
+        if (parentType == ParentType.RightShoulderPivot) {
+            poseStack.pushPose();
+            poseStack.translate(6 / 16f, 0f, 0f);
+            figura$renderArmorPart(model.rightArm, poseStack, vertexConsumers, light, entity, itemStack, armorSlot, armorItem);
+            poseStack.popPose();
+        }
+    }
+
+    @Unique
+    private void figura$leggingsRenderer(PoseStack poseStack, MultiBufferSource vertexConsumers, int light, A model, T entity, ItemStack itemStack, EquipmentSlot armorSlot, ArmorItem armorItem, ParentType parentType) {
+        if (parentType == ParentType.LeggingsPivot) {
+            poseStack.pushPose();
+            poseStack.translate(0, -12 / 16f, 0);
+            figura$renderArmorPart(model.body, poseStack, vertexConsumers, light, entity, itemStack, armorSlot, armorItem);
+            poseStack.popPose();
+        }
+
+        if (parentType == ParentType.LeftLeggingPivot) {
+            poseStack.pushPose();
+            poseStack.translate(2 / 16f, -12 / 16f, 0);
+            figura$renderArmorPart(model.leftLeg, poseStack, vertexConsumers, light, entity, itemStack, armorSlot, armorItem);
+            poseStack.popPose();
+        }
+
+        if (parentType == ParentType.RightLeggingPivot) {
+            poseStack.pushPose();
+            poseStack.translate(-2 / 16f, -12 / 16f, 0);
+            figura$renderArmorPart(model.rightLeg, poseStack, vertexConsumers, light, entity, itemStack, armorSlot, armorItem);
+            poseStack.popPose();
+        }
+    }
+
+    @Unique
+    private void figura$bootsRenderer(PoseStack poseStack, MultiBufferSource vertexConsumers, int light, A model, T entity, ItemStack itemStack, EquipmentSlot armorSlot, ArmorItem armorItem, ParentType parentType) {
+        if (parentType == ParentType.LeftBootPivot) {
+            poseStack.pushPose();
+            poseStack.translate(-2 / 16f, -24 / 16f, 0);
+            figura$renderArmorPart(model.leftLeg, poseStack, vertexConsumers, light, entity, itemStack, armorSlot, armorItem);
+            poseStack.popPose();
+        }
+
+        if (parentType == ParentType.RightBootPivot) {
+            poseStack.pushPose();
+            poseStack.translate(2 / 16f, -24 / 16f, 0);
+            figura$renderArmorPart(model.rightLeg, poseStack, vertexConsumers, light, entity, itemStack, armorSlot, armorItem);
+            poseStack.popPose();
+        }
+    }
+
+
+    // Similar to vanilla's renderArmorModel, but it renders each part individually, instead of the whole model at once.
+    // Could be optimized by calculating the tint, overlays, and trims beforehand instead of re-calculating for each ModelPart, but it's not super important.
+    @Unique
+    private void figura$renderArmorPart(ModelPart modelPart, PoseStack poseStack, MultiBufferSource vertexConsumers, int light, T entity, ItemStack itemStack, EquipmentSlot armorSlot, ArmorItem armorItem) {
+        boolean bl = this.usesInnerModel(armorSlot);
+        boolean hasOverlay = false;
+        boolean hasGlint = itemStack.hasFoil();
+
+        modelPart.visible = true;
+        modelPart.xRot = 0;
+        modelPart.yRot = 0;
+        modelPart.zRot = 0;
+
+        float tintR = 1;
+        float tintG = 1;
+        float tintB = 1;
+
+        if (armorItem instanceof DyeableArmorItem dyeableArmorItem) {
+            int i = dyeableArmorItem.getColor(itemStack);
+            tintR = (float) (i >> 16 & 255) / 255.0F;
+            tintG = (float) (i >> 8 & 255) / 255.0F;
+            tintB = (float) (i & 255) / 255.0F;
+            hasOverlay = true;
+        }
+
+        VertexConsumer regularArmorConsumer = vertexConsumers.getBuffer(RenderType.armorCutoutNoCull(this.getArmorLocation(armorItem, bl, null)));
+        modelPart.render(poseStack, regularArmorConsumer, light, OverlayTexture.NO_OVERLAY, tintR, tintG, tintB, 1f);
+
+        if (hasOverlay) {
+            VertexConsumer overlaidArmorConsumer = vertexConsumers.getBuffer(RenderType.armorCutoutNoCull(this.getArmorLocation(armorItem, bl, "overlay")));
+            modelPart.render(poseStack, overlaidArmorConsumer, light, OverlayTexture.NO_OVERLAY, 1f, 1f, 1f, 1f);
+        }
+
+        ArmorTrim.getTrim(entity.level().registryAccess(), itemStack).ifPresent((permutation) -> {
+            var armorMaterial = armorItem.getMaterial();
+            TextureAtlasSprite trimAtlas = this.armorTrimAtlas.getSprite(bl ? permutation.innerTexture(armorMaterial) : permutation.outerTexture(armorMaterial));
+            VertexConsumer trimConsumer = trimAtlas.wrap(vertexConsumers.getBuffer(Sheets.armorTrimsSheet()));
+            modelPart.render(poseStack, trimConsumer, light, OverlayTexture.NO_OVERLAY, 1.0f, 1.0f, 1.0f, 1.0f);
+        });
+
+        if (hasGlint) {
+            modelPart.render(poseStack, vertexConsumers.getBuffer(RenderType.armorEntityGlint()), light, OverlayTexture.NO_OVERLAY, 1.0f, 1.0f, 1.0f, 1.0f);
+        }
     }
 
     @Inject(at = @At("RETURN"), method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V")
     public void postRender(PoseStack poseStack, MultiBufferSource multiBufferSource, int i, T livingEntity, float f, float g, float h, float j, float k, float l, CallbackInfo ci) {
         avatar = null;
-    }
-
-    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/entity/layers/HumanoidArmorLayer;usesInnerModel(Lnet/minecraft/world/entity/EquipmentSlot;)Z"), method = "renderArmorPiece")
-    public void onRenderArmorPiece(PoseStack poseStack, MultiBufferSource multiBufferSource, T livingEntity, EquipmentSlot equipmentSlot, int i, A humanoidModel, CallbackInfo ci) {
-        VanillaPart part = RenderUtils.partFromSlot(avatar, equipmentSlot);
-        if (part != null) {
-            part.save(humanoidModel);
-            part.preTransform(humanoidModel);
-            part.posTransform(humanoidModel);
-        }
-    }
-
-    @Inject(at = @At("RETURN"), method = "renderArmorPiece")
-    public void postRenderArmorPiece(PoseStack poseStack, MultiBufferSource multiBufferSource, T livingEntity, EquipmentSlot equipmentSlot, int i, A humanoidModel, CallbackInfo ci) {
-        VanillaPart part = RenderUtils.partFromSlot(avatar, equipmentSlot);
-        if (part != null)
-            part.restore(humanoidModel);
     }
 }

--- a/common/src/main/java/org/figuramc/figura/mixin/render/layers/items/ItemInHandLayerMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/layers/items/ItemInHandLayerMixin.java
@@ -46,7 +46,7 @@ public abstract class ItemInHandLayerMixin<T extends LivingEntity, M extends Ent
 
         //pivot part
         if (avatar.pivotPartRender(left ? ParentType.LeftItemPivot : ParentType.RightItemPivot, stack -> {
-            float s = 16f;
+            final float s = 16f;
             stack.scale(s, s, s);
             stack.mulPose(Axis.XP.rotationDegrees(-90f));
             this.itemInHandRenderer.renderItem(livingEntity, itemStack, itemDisplayContext, left, stack, multiBufferSource, i);

--- a/common/src/main/java/org/figuramc/figura/model/ParentType.java
+++ b/common/src/main/java/org/figuramc/figura/model/ParentType.java
@@ -5,18 +5,26 @@ import org.figuramc.figura.math.vector.FiguraVec3;
 public enum ParentType {
     None("NONE", "Model", "MODEL"),
 
+    // Vanilla body parts
     Head(VanillaModelProvider.HEAD, "HEAD"),
     Body(VanillaModelProvider.BODY, "BODY"),
     LeftArm(VanillaModelProvider.LEFT_ARM, FiguraVec3.of(5, 2, 0), "LEFT_ARM"),
     RightArm(VanillaModelProvider.RIGHT_ARM, FiguraVec3.of(-5, 2, 0), "RIGHT_ARM"),
+
+    // Moving here because jank. Ex: if LeftLeg is before this one, then it reads [LeftLeg]gingPivot and picks the wrong one. Awesome.
+    LeftLeggingPivot(false, true, "LEFT_LEGGING_PIVOT", "LeftLeggingPivot"),
+    RightLeggingPivot(false, true, "RIGHT_LEGGING_PIVOT", "RightLeggingPivot"),
+
     LeftLeg(VanillaModelProvider.LEFT_LEG, FiguraVec3.of(1.9, 12, 0), "LEFT_LEG"),
     RightLeg(VanillaModelProvider.RIGHT_LEG, FiguraVec3.of(-1.9, 12, 0), "RIGHT_LEG"),
 
+    // Back accessories (Wings/Cape)
     LeftElytra(true, VanillaModelProvider.LEFT_ELYTRON, FiguraVec3.of(5, 0, 0), "LEFT_ELYTRA", "LeftElytron", "LEFT_ELYTRON"),
     RightElytra(true, VanillaModelProvider.RIGHT_ELYTRON, FiguraVec3.of(-5, 0, 0), "RIGHT_ELYTRA", "RightElytron", "RIGHT_ELYTRON"),
 
     Cape(true, VanillaModelProvider.FAKE_CAPE, FiguraVec3.of(), "CAPE"),
 
+    // Miscellaneous
     World(true, false, "WORLD"),
     Hud(true, false, "HUD", "HeadsUpDisplay", "Gui", "GUI", "GraphicalUserInterface", "JraficalUserInterface"),
     Camera("CAMERA", "Billboard", "BILLBOARD"),
@@ -25,13 +33,23 @@ public enum ParentType {
     Arrow(true, false, "ARROW"),
     Item(true, false, "ITEM"),
 
+    // Held items, birds, n stuff
     LeftItemPivot(false, true,"LEFT_ITEM_PIVOT"),
     RightItemPivot(false, true,"RIGHT_ITEM_PIVOT"),
     LeftSpyglassPivot(false, true,"LEFT_SPYGLASS_PIVOT"),
     RightSpyglassPivot(false, true,"RIGHT_SPYGLASS_PIVOT"),
-    HelmetItemPivot(false, true,"HELMET_ITEM_PIVOT"),
     LeftParrotPivot(false, true,"LEFT_PARROT_PIVOT"),
-    RightParrotPivot(false, true,"RIGHT_PARROT_PIVOT");
+    RightParrotPivot(false, true,"RIGHT_PARROT_PIVOT"),
+
+    // Armor
+    HelmetItemPivot(false, true,"HELMET_ITEM_PIVOT"),
+    HelmetPivot(false, true, "HELMET_PIVOT", "HelmetPivot"),
+    ChestplatePivot(false, true, "CHESTPLATE_PIVOT", "ChestplatePivot"),
+    LeftShoulderPivot(false, true, "LEFT_SHOULDER_PIVOT", "LeftShoulderPivot"),
+    RightShoulderPivot(false, true, "RIGHT_SHOULDER_PIVOT", "RightShoulderPivot"),
+    LeggingsPivot(false, true, "LEGGINGS_PIVOT", "LeggingsPivot"),
+    LeftBootPivot(false, true, "LEFT_BOOT_PIVOT", "LeftBootPivot"),
+    RightBootPivot(false, true, "RIGHT_BOOT_PIVOT", "RightBootPivot");
 
     public final VanillaModelProvider provider;
     public final FiguraVec3 offset;

--- a/common/src/main/java/org/figuramc/figura/model/VanillaModelProvider.java
+++ b/common/src/main/java/org/figuramc/figura/model/VanillaModelProvider.java
@@ -1,6 +1,7 @@
 package org.figuramc.figura.model;
 
 import net.minecraft.client.model.EntityModel;
+import net.minecraft.client.model.HumanoidArmorModel;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.model.PlayerModel;
 import net.minecraft.client.model.geom.ModelPart;
@@ -10,22 +11,22 @@ import org.figuramc.figura.mixin.render.layers.elytra.ElytraModelAccessor;
 import java.util.function.Function;
 
 public enum VanillaModelProvider {
-    HEAD(model -> model instanceof HumanoidModel m ? m.head : null),
-    BODY(model -> model instanceof HumanoidModel m ? m.body : null),
-    LEFT_ARM(model -> model instanceof HumanoidModel m ? m.leftArm : null),
-    RIGHT_ARM(model -> model instanceof HumanoidModel m ? m.rightArm : null),
-    LEFT_LEG(model -> model instanceof HumanoidModel m ? m.leftLeg : null),
-    RIGHT_LEG(model -> model instanceof HumanoidModel m ? m.rightLeg : null),
-    HAT(model -> model instanceof HumanoidModel m ? m.hat : null),
+    HEAD(model -> model instanceof HumanoidModel<?> m ? m.head : null),
+    BODY(model -> model instanceof HumanoidModel<?> m ? m.body : null),
+    LEFT_ARM(model -> model instanceof HumanoidModel<?> m ? m.leftArm : null),
+    RIGHT_ARM(model -> model instanceof HumanoidModel<?> m ? m.rightArm : null),
+    LEFT_LEG(model -> model instanceof HumanoidModel<?> m ? m.leftLeg : null),
+    RIGHT_LEG(model -> model instanceof HumanoidModel<?> m ? m.rightLeg : null),
+    HAT(model -> model instanceof HumanoidModel<?> m ? m.hat : null),
 
-    JACKET(model -> model instanceof PlayerModel m ? m.jacket : null),
-    LEFT_SLEEVE(model -> model instanceof PlayerModel m ? m.leftSleeve : null),
-    RIGHT_SLEEVE(model -> model instanceof PlayerModel m ? m.rightSleeve : null),
-    LEFT_PANTS(model -> model instanceof PlayerModel m ? m.leftPants : null),
-    RIGHT_PANTS(model -> model instanceof PlayerModel m ? m.rightPants : null),
+    JACKET(model -> model instanceof PlayerModel<?> m ? m.jacket : null),
+    LEFT_SLEEVE(model -> model instanceof PlayerModel<?> m ? m.leftSleeve : null),
+    RIGHT_SLEEVE(model -> model instanceof PlayerModel<?> m ? m.rightSleeve : null),
+    LEFT_PANTS(model -> model instanceof PlayerModel<?> m ? m.leftPants : null),
+    RIGHT_PANTS(model -> model instanceof PlayerModel<?> m ? m.rightPants : null),
 
-    CAPE(model -> model instanceof PlayerModel m ? ((PlayerModelAccessor) m).figura$getCloak() : null),
-    FAKE_CAPE(model -> model instanceof PlayerModel m ? ((PlayerModelAccessor) m).figura$getFakeCloak() : null),
+    CAPE(model -> model instanceof PlayerModel<?> m ? ((PlayerModelAccessor) m).figura$getCloak() : null),
+    FAKE_CAPE(model -> model instanceof PlayerModel<?> m ? ((PlayerModelAccessor) m).figura$getFakeCloak() : null),
 
     LEFT_ELYTRON(model -> model instanceof ElytraModelAccessor m ? m.getLeftWing() : null),
     RIGHT_ELYTRON(model -> model instanceof ElytraModelAccessor m ? m.getRightWing() : null);

--- a/common/src/main/java/org/figuramc/figura/model/rendering/AvatarRenderer.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendering/AvatarRenderer.java
@@ -60,7 +60,7 @@ public abstract class AvatarRenderer {
     public VanillaModelData vanillaModelData = new VanillaModelData();
 
     public PartFilterScheme currentFilterScheme;
-    public final HashMap<ParentType, ConcurrentLinkedQueue<Pair<FiguraMat4, FiguraMat3>>> pivotCustomizations = new HashMap<>();
+    public final HashMap<ParentType, ConcurrentLinkedQueue<Pair<FiguraMat4, FiguraMat3>>> pivotCustomizations = new HashMap<>(ParentType.values().length);
     protected final List<FiguraTextureSet> textureSets = new ArrayList<>();
     public final HashMap<String, FiguraTexture> textures = new HashMap<>();
     public final HashMap<String, FiguraTexture> customTextures = new HashMap<>();

--- a/common/src/main/java/org/figuramc/figura/utils/FiguraArmorPartRenderer.java
+++ b/common/src/main/java/org/figuramc/figura/utils/FiguraArmorPartRenderer.java
@@ -1,0 +1,15 @@
+package org.figuramc.figura.utils;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.model.HumanoidModel;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ArmorItem;
+import net.minecraft.world.item.ItemStack;
+import org.figuramc.figura.model.ParentType;
+
+public interface FiguraArmorPartRenderer<T extends LivingEntity, M extends HumanoidModel<T>, A extends HumanoidModel<T>> {
+    void renderArmorPart(PoseStack poseStack, MultiBufferSource vertexConsumers, int light, A model, T entity, ItemStack itemStack, EquipmentSlot armorSlot, ArmorItem armorItem, ParentType parentType);
+}
+

--- a/common/src/main/java/org/figuramc/figura/wizards/AvatarWizard.java
+++ b/common/src/main/java/org/figuramc/figura/wizards/AvatarWizard.java
@@ -14,7 +14,6 @@ import org.figuramc.figura.utils.*;
 import org.figuramc.figura.exporters.BlockBenchModel;
 import org.figuramc.figura.exporters.BlockBenchModel.Cube;
 import org.figuramc.figura.exporters.BlockBenchModel.Group;
-import org.figuramc.figura.utils.*;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -22,6 +21,27 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.function.BiFunction;
 
+import static org.figuramc.figura.model.ParentType.*;
+
+/*
+                  .
+
+                   .
+         /^\     .
+    /\   "V"
+   /__\   I      O  o
+  //..\\  I     .
+  \].`[/  I
+  /l\/j\  (]    .  O
+ /. ~~ ,\/I          .
+ \\L__j^\/I       o
+  \/--v}  I     o   .
+  |    |  I   _________
+  |    |  I c(`       ')o
+  |    l  I   \.     ,/
+_/j  L l\_!  _//^---^\\_
+
+ */
 public class AvatarWizard {
 
     private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
@@ -70,7 +90,7 @@ public class AvatarWizard {
                 continue;
 
             Object obj = map.get(dependency);
-            if (obj == null || !dependency.validade(obj))
+            if (obj == null || !dependency.validate(obj))
                 return false;
 
             boolean bl = switch (dependency.type) {
@@ -229,6 +249,7 @@ public class AvatarWizard {
         boolean hasCape = WizardEntry.CAPE.asBool(map);
         boolean hasCapeOrElytra = hasCape || hasElytra;
         boolean slim = WizardEntry.SLIM.asBool(map);
+        boolean hasArmor = WizardEntry.ARMOR_PIVOTS.asBool(map);
 
         //model
         BlockBenchModel model = new BlockBenchModel("free");
@@ -246,12 +267,12 @@ public class AvatarWizard {
         //base bones
         Group root = model.addGroup("root", FiguraVec3.of());
 
-        Group head = model.addGroup("Head", FiguraVec3.of(0, 24, 0), root);
-        Group body = model.addGroup("Body", FiguraVec3.of(0, 24, 0), root);
-        Group leftArm = model.addGroup("LeftArm", FiguraVec3.of(-5, 22, 0), root);
-        Group rightArm = model.addGroup("RightArm", FiguraVec3.of(5, 22, 0), root);
-        Group leftLeg = model.addGroup("LeftLeg", FiguraVec3.of(-1.9, 12, 0), root);
-        Group rightLeg = model.addGroup("RightLeg", FiguraVec3.of(1.9, 12, 0), root);
+        Group head = model.addGroup(Head, FiguraVec3.of(0, 24, 0), root);
+        Group body = model.addGroup(Body, FiguraVec3.of(0, 24, 0), root);
+        Group leftArm = model.addGroup(LeftArm, FiguraVec3.of(-5, 22, 0), root);
+        Group rightArm = model.addGroup(RightArm, FiguraVec3.of(5, 22, 0), root);
+        Group leftLeg = model.addGroup(LeftLeg, FiguraVec3.of(-1.9, 12, 0), root);
+        Group rightLeg = model.addGroup(RightLeg, FiguraVec3.of(1.9, 12, 0), root);
 
         //player
         if (hasPlayer) {
@@ -268,7 +289,7 @@ public class AvatarWizard {
 
         //cape
         if (hasCape) {
-            Group cape = model.addGroup("Cape", FiguraVec3.of(0, 24, 2), root);
+            Group cape = model.addGroup(Cape, FiguraVec3.of(0, 24, 2), root);
             Cube cube = model.addCube("Cape", FiguraVec3.of(-5, 8, 2), FiguraVec3.of(10, 16, 1), cape);
             cube.generateBoxFaces(0, 0, capeTex, 1, hasPlayer ? 2 : 1);
         }
@@ -278,13 +299,13 @@ public class AvatarWizard {
             Group elytra = model.addGroup("Elytra", FiguraVec3.of(0, 24, 2), root);
 
             //left wing
-            Group leftElytra = model.addGroup("LeftElytra", FiguraVec3.of(-5, 24, 2), elytra);
+            Group leftElytra = model.addGroup(LeftElytra, FiguraVec3.of(-5, 24, 2), elytra);
             Cube cube = model.addCube(FiguraVec3.of(-5, 4, 2), FiguraVec3.of(10, 20, 2), leftElytra);
             cube.inflate = 1;
             cube.generateBoxFaces(22, 0, capeTex, 1, hasPlayer ? 2 : 1);
 
             //right wing
-            Group rightElytra = model.addGroup("RightElytra", FiguraVec3.of(5, 24, 2), elytra);
+            Group rightElytra = model.addGroup(RightElytra, FiguraVec3.of(5, 24, 2), elytra);
             cube = model.addCube(FiguraVec3.of(-5, 4, 2), FiguraVec3.of(10, 20, 2), rightElytra);
             cube.inflate = 1;
             cube.generateBoxFaces(22, 0, capeTex, -1, hasPlayer ? 2 : 1);
@@ -292,22 +313,34 @@ public class AvatarWizard {
 
         //pivots
         if (WizardEntry.ITEMS_PIVOT.asBool(map)) {
-            model.addGroup("LeftItemPivot", FiguraVec3.of(slim ? -5.5 : -6, 12, -2), leftArm);
-            model.addGroup("RightItemPivot", FiguraVec3.of(slim ? 5.5 : 6, 12, -2), rightArm);
+            model.addGroup(LeftItemPivot, FiguraVec3.of(slim ? -5.5 : -6, 12, -2), leftArm);
+            model.addGroup(RightItemPivot, FiguraVec3.of(slim ? 5.5 : 6, 12, -2), rightArm);
         }
 
         if (WizardEntry.SPYGLASS_PIVOT.asBool(map)) {
-            model.addGroup("LeftSpyglassPivot", FiguraVec3.of(-2, 28, -4), head);
-            model.addGroup("RightSpyglassPivot", FiguraVec3.of(2, 28, -4), head);
+            model.addGroup(LeftSpyglassPivot, FiguraVec3.of(-2, 28, -4), head);
+            model.addGroup(RightSpyglassPivot, FiguraVec3.of(2, 28, -4), head);
         }
 
         if (WizardEntry.HELMET_ITEM_PIVOT.asBool(map)) {
-            model.addGroup("HelmetItemPivot", FiguraVec3.of(0, 24, 0), head);
+            model.addGroup(HelmetItemPivot, FiguraVec3.of(0, 24, 0), head);
         }
 
         if (WizardEntry.PARROTS_PIVOT.asBool(map)) {
-            model.addGroup("LeftParrotPivot", FiguraVec3.of(-6, 24, 0), body);
-            model.addGroup("RightParrotPivot", FiguraVec3.of(6, 24, 0), body);
+            model.addGroup(LeftParrotPivot, FiguraVec3.of(-6, 24, 0), body);
+            model.addGroup(RightParrotPivot, FiguraVec3.of(6, 24, 0), body);
+        }
+
+        if (hasArmor) {
+            model.addGroup(HelmetPivot, FiguraVec3.of(0, 24, 0), head);
+            model.addGroup(ChestplatePivot, FiguraVec3.of(0, 24, 0), body);
+            model.addGroup(LeftShoulderPivot, FiguraVec3.of(-6, 24, 0), leftArm);
+            model.addGroup(RightShoulderPivot, FiguraVec3.of(6, 24, 0), rightArm);
+            model.addGroup(LeggingsPivot, FiguraVec3.of(0, 12, 0), body);
+            model.addGroup(LeftLeggingPivot, FiguraVec3.of(2, 12, 0), leftLeg);
+            model.addGroup(RightLeggingPivot, FiguraVec3.of(-2, 12, 0), rightLeg);
+            model.addGroup(LeftBootPivot, FiguraVec3.of(-2, 0, 0), leftLeg);
+            model.addGroup(RightBootPivot, FiguraVec3.of(2, 0, 0), rightLeg);
         }
 
         //return
@@ -320,68 +353,5 @@ public class AvatarWizard {
         Cube l = model.addCube(layerName, position, size, parent);
         l.inflate = inflation;
         l.generateBoxFaces(x2, y2, texture);
-    }
-
-    public enum WizardEntry {
-        //metadata
-        Meta(Type.CATEGORY),
-        NAME(Type.TEXT),
-        DESCRIPTION(Type.TEXT, NAME),
-        AUTHORS(Type.TEXT, NAME),
-        //model stuff
-        Model(Type.CATEGORY, NAME),
-        DUMMY_MODEL(Model),
-        PLAYER_MODEL(DUMMY_MODEL),
-        SLIM(PLAYER_MODEL),
-        CAPE(DUMMY_MODEL),
-        ELYTRA(DUMMY_MODEL),
-        //pivots
-        Pivots(Type.CATEGORY, DUMMY_MODEL),
-        ITEMS_PIVOT(Pivots),
-        SPYGLASS_PIVOT(Pivots),
-        HELMET_ITEM_PIVOT(Pivots),
-        PARROTS_PIVOT(Pivots),
-        //scripting
-        Scripting(Type.CATEGORY, NAME),
-        DUMMY_SCRIPT(Scripting),
-        HIDE_PLAYER(PLAYER_MODEL, DUMMY_SCRIPT),
-        HIDE_ARMOR(DUMMY_SCRIPT),
-        HIDE_CAPE(DUMMY_SCRIPT),
-        HIDE_ELYTRA(DUMMY_SCRIPT),
-        EMPTY_EVENTS(DUMMY_SCRIPT);
-
-        private final Type type;
-        private final WizardEntry[] dependencies;
-
-        WizardEntry(WizardEntry... dependencies) {
-            this(Type.TOGGLE, dependencies);
-        }
-        WizardEntry(Type type, WizardEntry... dependencies) {
-            this.type = type;
-            this.dependencies = dependencies;
-        }
-
-        public Type getType() {
-            return type;
-        }
-
-        public boolean validade(Object object) {
-            return switch (type) {
-                case TOGGLE -> object instanceof Boolean;
-                case TEXT -> object instanceof String;
-                case CATEGORY -> true;
-            };
-        }
-
-        public boolean asBool(HashMap<WizardEntry, Object> map) {
-            Object object = map.get(this);
-            return type == Type.TOGGLE && object != null && (boolean) object;
-        }
-
-        public enum Type {
-            TOGGLE,
-            TEXT,
-            CATEGORY
-        }
     }
 }

--- a/common/src/main/java/org/figuramc/figura/wizards/WizardEntry.java
+++ b/common/src/main/java/org/figuramc/figura/wizards/WizardEntry.java
@@ -1,0 +1,87 @@
+package org.figuramc.figura.wizards;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+
+public class WizardEntry {
+    private static final HashMap<String, WizardEntry> ENTRY_LOOKUP = new LinkedHashMap<>();
+
+    public static final WizardEntry Meta = register("Meta", WizardEntry.Type.CATEGORY);
+    public static final WizardEntry NAME = register("NAME", WizardEntry.Type.TEXT);
+    public static final WizardEntry DESCRIPTION = register("DESCRIPTION", WizardEntry.Type.TEXT, NAME);
+    public static final WizardEntry AUTHORS = register("AUTHORS", WizardEntry.Type.TEXT, NAME);
+    public static final WizardEntry Model = register("Model", WizardEntry.Type.CATEGORY, NAME);
+    public static final WizardEntry DUMMY_MODEL = register("DUMMY_MODEL", Model);
+    public static final WizardEntry PLAYER_MODEL = register("PLAYER_MODEL", DUMMY_MODEL);
+    public static final WizardEntry SLIM = register("SLIM", PLAYER_MODEL);
+    public static final WizardEntry CAPE = register("CAPE", DUMMY_MODEL);
+    public static final WizardEntry ELYTRA = register("ELYTRA", DUMMY_MODEL);
+    public static final WizardEntry Pivots = register("Pivots", WizardEntry.Type.CATEGORY, DUMMY_MODEL);
+    public static final WizardEntry ITEMS_PIVOT = register("ITEMS_PIVOT", Pivots);
+    public static final WizardEntry SPYGLASS_PIVOT = register("SPYGLASS_PIVOT", Pivots);
+    public static final WizardEntry HELMET_ITEM_PIVOT = register("HELMET_ITEM_PIVOT", Pivots);
+    public static final WizardEntry PARROTS_PIVOT = register("PARROTS_PIVOT", Pivots);
+    public static final WizardEntry ARMOR_PIVOTS = register("ARMOR_PIVOTS", Pivots);
+    public static final WizardEntry Scripting = register("Scripting", WizardEntry.Type.CATEGORY, NAME);
+    public static final WizardEntry DUMMY_SCRIPT = register("DUMMY_SCRIPT", Scripting);
+    public static final WizardEntry HIDE_PLAYER = register("HIDE_PLAYER", PLAYER_MODEL, DUMMY_SCRIPT);
+    public static final WizardEntry HIDE_ARMOR = register("HIDE_ARMOR", DUMMY_SCRIPT);
+    public static final WizardEntry HIDE_CAPE = register("HIDE_CAPE", DUMMY_SCRIPT);
+    public static final WizardEntry HIDE_ELYTRA = register("HIDE_ELYTRA", DUMMY_SCRIPT);
+    public static final WizardEntry EMPTY_EVENTS = register("EMPTY_EVENTS", DUMMY_SCRIPT);
+
+    public static WizardEntry get(String name) {
+        return ENTRY_LOOKUP.get(name);
+    }
+
+    public static boolean exists(String name) {
+        return ENTRY_LOOKUP.containsKey(name);
+    }
+
+    public static Collection<WizardEntry> all() {
+        return ENTRY_LOOKUP.values();
+    }
+
+    public final String name;
+    public final WizardEntry.Type type;
+    public final WizardEntry[] dependencies;
+
+    WizardEntry(String name, WizardEntry... dependencies) {
+        this(name, WizardEntry.Type.TOGGLE, dependencies);
+    }
+    WizardEntry(String name, WizardEntry.Type type, WizardEntry... dependencies) {
+        this.name = name;
+        this.type = type;
+        this.dependencies = dependencies;
+    }
+
+    public boolean validate(Object object) {
+        return switch (type) {
+            case TOGGLE -> object instanceof Boolean;
+            case TEXT -> object instanceof String;
+            case CATEGORY -> true;
+        };
+    }
+
+    public boolean asBool(HashMap<WizardEntry, Object> map) {
+        Object object = map.get(this);
+        return type == WizardEntry.Type.TOGGLE && object != null && (boolean) object;
+    }
+
+    public enum Type {
+        TOGGLE,
+        TEXT,
+        CATEGORY
+    }
+
+    public static WizardEntry register(String name, WizardEntry.Type type, WizardEntry... dependencies) {
+        WizardEntry entry = new WizardEntry(name, type, dependencies);
+        ENTRY_LOOKUP.put(name, entry);
+        return entry;
+    }
+
+    public static WizardEntry register(String name, WizardEntry... dependencies) {
+        return register(name, Type.TOGGLE, dependencies);
+    }
+}

--- a/common/src/main/resources/figura-common.mixins.json
+++ b/common/src/main/resources/figura-common.mixins.json
@@ -57,6 +57,7 @@
     "render.TextureManagerAccessor",
     "render.layers.CapeLayerMixin",
     "render.layers.CustomHeadLayerMixin",
+    "render.layers.HumanoidArmorLayerAccessor",
     "render.layers.HumanoidArmorLayerMixin",
     "render.layers.ParrotOnShoulderLayerMixin",
     "render.layers.elytra.ElytraLayerAccessor",

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,4 +11,4 @@ include("common")
 include("fabric")
 include("forge")
 
-rootProject.name = "figura"
+rootProject.name = "Figura"


### PR DESCRIPTION
Added support for armor pivots in BlockBench, so user's don't have to use code to manually offset armor anymore. Works with enchantment glints, trims, and dyes. 

Also added the pivots to the avatar wizard.

Finally, I also refactored a few random things