### PR TITLE
2 lines, that broke it all (version 2, electric boogaloo)

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/FiguraLuaRuntime.java
+++ b/common/src/main/java/org/figuramc/figura/lua/FiguraLuaRuntime.java
@@ -24,6 +24,7 @@ import org.luaj.vm2.compiler.LuaC;
 import org.luaj.vm2.lib.*;
 import org.luaj.vm2.lib.jse.JseBaseLib;
 import org.luaj.vm2.lib.jse.JseMathLib;
+import org.luaj.vm2.lib.jse.JseStringLib;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -71,7 +72,7 @@ public class FiguraLuaRuntime {
         userGlobals.load(new JseBaseLib());
         userGlobals.load(new Bit32Lib());
         userGlobals.load(new TableLib());
-        userGlobals.load(new StringLib());
+        userGlobals.load(new JseStringLib());
         userGlobals.load(new JseMathLib());
 
         LuaC.install(userGlobals);


### PR DESCRIPTION
This pr (hopefully) fixes `string.format` ignoring floating point formats, for some reason default implementation for both java SE and ME uses just `String.valueOf(double)` and only `JseStringLib` expands it to use `String.format(format, values)`
(i did very surface-level test with `a = 12.34 print(("|%f|%3.3f|% 4.1f"):format(a, a, a))`
(also removed one of `f`'s allergic "never use features" moments)