### PR TITLE
Add Optifine and Optifabric support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ remappedSrc/
 # Forge MDK
 
 forge*changelog.txt
+
+#Used for testing against other mods
+libs/*

--- a/README.md
+++ b/README.md
@@ -107,15 +107,15 @@ Meet us on the [FiguraMC Discord Server](https://discord.gg/figuramc) for more i
 > 
 > And don't forget to set the places you don't want to glow to **transparent black** (#00000000), to also ensure compatibility with shader mods
 
-### • My emissives doesn't glow, nor have bloom with Iris shaders?
+### • My emissives doesn't glow, nor have bloom with Iris/Optifine shaders?
 > Since some shaders doesnt support emissives, a compatibility setting (default on) will change the render type of emissive textures to render them at it were fullbright, however that can lead to some unintended results
 >
 > You can force your avatar to use the correct emissive render type by using the render type `EYES` on your model
 
 ### • How can I use Figura with OptiFine?
-> You can't, OptiFine's closed-source nature and invasive code makes mod compatibility very difficult
+> Figura works with Optifine however we still reccomend you try using Sodium/Iris or Rubidium/Oculus instead.
 > 
-> Check out these [alternatives](https://lambdaurora.dev/optifine_alternatives/) instead
+> Check out the full list of [alternatives](https://lambdaurora.dev/optifine_alternatives/) instead
 
 ### • Where can I find Avatars to download?
 > For now you can find Avatars in the showcase channel in the official Discord server (A Web Based and In-Game browser is in the works!)

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Meet us on the [FiguraMC Discord Server](https://discord.gg/figuramc) for more i
 > You can force your avatar to use the correct emissive render type by using the render type `EYES` on your model
 
 ### • How can I use Figura with OptiFine?
-> Figura works with Optifine however we still reccomend you try using Sodium/Iris or Rubidium/Oculus instead
+> Figura will work with Optifine but due it's closed source nature issues might arise, therefore we still recommend you try using Sodium+Iris (Fabric) or Rubidium+Oculus (Forge) instead
 > 
 > Check out the full list of [alternatives](https://lambdaurora.dev/optifine_alternatives/)
 

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ Meet us on the [FiguraMC Discord Server](https://discord.gg/figuramc) for more i
 > You can force your avatar to use the correct emissive render type by using the render type `EYES` on your model
 
 ### • How can I use Figura with OptiFine?
-> Figura works with Optifine however we still reccomend you try using Sodium/Iris or Rubidium/Oculus instead.
+> Figura works with Optifine however we still reccomend you try using Sodium/Iris or Rubidium/Oculus instead
 > 
-> Check out the full list of [alternatives](https://lambdaurora.dev/optifine_alternatives/) instead
+> Check out the full list of [alternatives](https://lambdaurora.dev/optifine_alternatives/)
 
 ### • Where can I find Avatars to download?
 > For now you can find Avatars in the showcase channel in the official Discord server (A Web Based and In-Game browser is in the works!)

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -8,6 +8,9 @@ loom {
 
 repositories {
     maven { url 'https://jitpack.io' }
+    flatDir {
+        dirs "$rootProject.projectDir/libs"
+    }
 }
 
 dependencies {
@@ -19,6 +22,9 @@ dependencies {
     // We depend on fabric loader here to use the fabric @Environment annotations and get the mixin dependencies
     // Do NOT use other classes from fabric loader
     modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
+
+    // Test compile only is used to mount sources on an IDE without overriding vanilla classes with Optifine's
+    testCompileOnly fileTree(dir: "$rootProject.projectDir/libs", include: '*.jar')
 }
 
 publishing {

--- a/common/src/main/java/org/figuramc/figura/lua/api/ClientAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/ClientAPI.java
@@ -334,6 +334,9 @@ public class ClientAPI {
             value = "client.is_mod_loaded"
     )
     public static boolean isModLoaded(String id) {
+        if (Objects.equals(id, "optifine") || Objects.equals(id, "optifabric"))
+            return OPTIFINE_LOADED.get();
+
         LOADED_MODS.putIfAbsent(id, PlatformUtils.isModLoaded(id));
         return LOADED_MODS.get(id);
     }

--- a/common/src/main/java/org/figuramc/figura/mixin/particle/ParticleEngineMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/particle/ParticleEngineMixin.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
@@ -26,9 +27,11 @@ public abstract class ParticleEngineMixin implements ParticleEngineAccessor {
 
     @Unique private final HashMap<Particle, UUID> particleMap = new HashMap<>();
 
-    @Inject(at = @At(value = "INVOKE", target = "Ljava/util/Iterator;remove()V"), method = "tickParticleList", locals = LocalCapture.CAPTURE_FAILSOFT)
-    private void tickParticleList(Collection<Particle> particles, CallbackInfo ci, Iterator<Particle> iterator, Particle particle) {
+    // This fixes a conflict with Optifine having slightly different args + it should be more stable in general, capturing Locals is bad practice
+    @ModifyVariable(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/particle/ParticleEngine;tickParticle(Lnet/minecraft/client/particle/Particle;)V"), method = "tickParticleList", ordinal = 0)
+    private Particle tickParticleList(Particle particle) {
         particleMap.remove(particle);
+        return particle;
     }
 
     @Override @Intrinsic

--- a/common/src/main/java/org/figuramc/figura/mixin/render/GameRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/GameRendererMixin.java
@@ -148,8 +148,20 @@ public abstract class GameRendererMixin implements GameRendererAccessor {
             slice = @Slice(
                     from = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GameRenderer;bobHurt(Lcom/mojang/blaze3d/vertex/PoseStack;F)V"),
                     to = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GameRenderer;resetProjectionMatrix(Lorg/joml/Matrix4f;)V")
-            ), locals = LocalCapture.CAPTURE_FAILSOFT)
+            ), locals = LocalCapture.CAPTURE_FAILSOFT, require = 0)
     private void renderLevelSaveBobbing(float tickDelta, long limitTime, PoseStack matrix, CallbackInfo ci, boolean bl, Camera camera, PoseStack poseStack, double d) {
+        if (hasShaders) return;
+        bobbingMatrix = new Matrix4f(poseStack.last().pose());
+        poseStack.popPose();
+    }
+
+    // Optifine slightly changes the locals here, adds an extra boolean
+    @Inject(method = "renderLevel", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;last()Lcom/mojang/blaze3d/vertex/PoseStack$Pose;", shift = At.Shift.BEFORE),
+            slice = @Slice(
+                    from = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GameRenderer;bobHurt(Lcom/mojang/blaze3d/vertex/PoseStack;F)V"),
+                    to = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GameRenderer;resetProjectionMatrix(Lorg/joml/Matrix4f;)V")
+            ), locals = LocalCapture.CAPTURE_FAILSOFT, require = 0)
+    private void renderLevelSaveBobbingOF(float tickDelta, long limitTime, PoseStack matrix, CallbackInfo ci, boolean bl, boolean bl2, Camera camera, PoseStack poseStack, double d) {
         if (hasShaders) return;
         bobbingMatrix = new Matrix4f(poseStack.last().pose());
         poseStack.popPose();

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/BlockEntityWithoutLevelRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/BlockEntityWithoutLevelRendererMixin.java
@@ -14,8 +14,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(BlockEntityWithoutLevelRenderer.class)
 public class BlockEntityWithoutLevelRendererMixin {
 
-    @Inject(method = "renderByItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/blockentity/SkullBlockRenderer;renderSkull(Lnet/minecraft/core/Direction;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/model/SkullModelBase;Lnet/minecraft/client/renderer/RenderType;)V"))
+    @Inject(method = "renderByItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/blockentity/SkullBlockRenderer;renderSkull(Lnet/minecraft/core/Direction;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/model/SkullModelBase;Lnet/minecraft/client/renderer/RenderType;)V"), require = 0)
     void setTargetItem(ItemStack stack, ItemDisplayContext itemDisplayContext, PoseStack matrices, MultiBufferSource vertexConsumers, int light, int overlay, CallbackInfo ci) {
+        SkullBlockRendererAccessor.setItem(stack);
+    }
+
+    // Optifine moves the place where Figura injects into a different method
+    @Inject(method = "renderRaw", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/blockentity/SkullBlockRenderer;renderSkull(Lnet/minecraft/core/Direction;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/model/SkullModelBase;Lnet/minecraft/client/renderer/RenderType;)V"), remap = false, require = 0)
+    void setTargetItem(ItemStack stack, PoseStack matrixStackIn, MultiBufferSource bufferIn, int combinedLightIn, int combinedOverlayIn, CallbackInfo ci) {
         SkullBlockRendererAccessor.setItem(stack);
     }
 }

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/SignRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/SignRendererMixin.java
@@ -12,7 +12,8 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 @Mixin(SignRenderer.class)
 public class SignRendererMixin {
 
-    @ModifyArg(method = "method_45799", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Font;split(Lnet/minecraft/network/chat/FormattedText;I)Ljava/util/List;"))
+    // method_45799 corresponds to fabric intermediary, lambda$renderSignText$2 is the unmapped OF name, m_244733_ is the SRG name for Forge
+    @ModifyArg(method = {"method_45799", "lambda$renderSignText$2", "m_244733_"}, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Font;split(Lnet/minecraft/network/chat/FormattedText;I)Ljava/util/List;", remap = true), remap = false)
     private FormattedText modifyText(FormattedText charSequence) {
         return Configs.EMOJIS.value > 0 && charSequence instanceof Component text ? Emojis.applyEmojis(text) : charSequence;
     }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -40,8 +40,6 @@
     "immediatelyfast":  "*"
   },
   "breaks": {
-    "optifine": "*",
-    "optifabric": "*"
   },
   "custom": {
     "assets_version": "${assets_version}",

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -39,8 +39,6 @@
     "canvas": "*",
     "immediatelyfast":  "*"
   },
-  "breaks": {
-  },
   "custom": {
     "assets_version": "${assets_version}",
     "modmenu": {


### PR DESCRIPTION
It was actually quite shrimple
This also fixes Oculus on Forge not being detected, as the mod id changes from iris to oculus.  

This is what was used to view Optifine's Source
[https://github.com/Cadiboo/OptiFineDeobf](https://github.com/Cadiboo/OptiFineDeobf)
It was created for use with pure Forge but because it remaps to Mojmap it works out. You just feed it an extracted Optifine Mod jar, (you can get this by opening the installer and pressing Extract instead of Install), you will also need a file that maps from SRG to Mojmap, then toggle 'Make Public' and 'Forge Dev jar and finally press Deobf
[NoCubes also has a guide for working alongside OF](https://github.com/Cadiboo/NoCubes#optifine-compatibility)

There is no actual dependency on Optifine itself so it is not required for compiling, it is optional and can be dropped in the libs folder, in the few places that OF's classes are referenced (just checking if shaders are on), it is done through Reflection so if the class is not present nothing happens.

Feel free to ask away if there's any questions, doubts or concerns. 