### PR TITLE
Update Jitpack's JDK, Quilt Loader, Enhance comments.

### DIFF
--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -1,4 +1,4 @@
 # loom.platform = quilt
 
 # Uncomment this ^ and change rootProject's "run_on_quilt" to true to run on quilt,
-# However it is not recommended building with this enabled however.
+# However building with this enabled is not recommended.

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -1,2 +1,4 @@
-# loom.platform=quilt
-# Uncomment this ^ and change rootProject's run_on_quilt to true to run on quilt, i wouldn't recommend building with this on
+# loom.platform = quilt
+
+# Uncomment this ^ and change rootProject's "run_on_quilt" to true to run on quilt,
+# However it is not recommended building with this enabled however.

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,6 +36,8 @@ iris = 1.6.4+1.20
 forge_version = 1.20.1-47.1.37
 
 # Quilt properties
+# https://lambdaurora.dev/tools/import_quilt.html
+# https://modrinth.com/mod/qsl
 quilt_loader_version = 0.20.0-beta.5
 quilt_fabric_api_version = 7.0.6+0.85.0-1.20.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,11 +35,13 @@ iris = 1.6.4+1.20
 # https://files.minecraftforge.net/net/minecraftforge/forge
 forge_version = 1.20.1-47.1.37
 
-#Quilt properties
-quilt_loader_version=0.19.0-beta.11
-quilt_fabric_api_version=7.0.6+0.85.0-1.20.1
+# Quilt properties
+quilt_loader_version = 0.20.0-beta.5
+quilt_fabric_api_version = 7.0.6+0.85.0-1.20.1
 
-#Extra
+# Extra properties
 run_on_quilt = false
-#To run on quilt you must set this to true and go to fabric/gradle.properties to uncomment loom.platform=quilt
-#To be clear this is for testing Figura on Quilt in a dev env only, not for building and it will not produce a native quilt mod
+
+# To run on quilt you must set this to true and go to fabric/gradle.properties to uncomment "loom.platform = quilt",
+# and to clarify; This is for testing Figura on Quilt in a development environment only and not for building,
+# therefore it will not produce a native quilt mod in this case.

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,5 @@
+jdk:
+  - temurinjdk17
 before_install:
    - curl -s "https://get.sdkman.io" | bash
    - source "$HOME/.sdkman/bin/sdkman-init.sh"

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,5 @@
 before_install:
    - curl -s "https://get.sdkman.io" | bash
    - source "$HOME/.sdkman/bin/sdkman-init.sh"
-   - sdk install java 17.0.7+7-tem
-   - sdk use java 17.0.7+7-tem
+   - sdk install java 17.0.8+7-tem
+   - sdk use java 17.0.8+7-tem


### PR DESCRIPTION
1. Updates the quilt loader version to 0.20.0 beta to ship with certain patches along the way, *(Requires testing)*
2. The Jitpack JDK will be updated to 17.0.8+7 to address time-zone related bugs and that the JDK's code now defaults to C99 or later, *(+ also fixes the use of C23 attributes)*
3. A few comments have been enhanced to not look as messy - Also now clarifies where QSL and quilt loader updates are trackable. *(This part was done optionally although better than nothing)*