### PR TITLE
Check for latest JDK, Validate Gradle distribution source, Final dependency patches.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,5 @@
 name: Build Figura using Gradle
 on: [pull_request, push]
-
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -12,8 +11,9 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          distribution: "temurin"
+          distribution: 'temurin'
           java-version: 17
+          check-latest: true
       - name: Build using Gradle
         run: |
          chmod +x gradlew

--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,5 @@ remappedSrc/
 
 forge*changelog.txt
 
-#Used for testing against other mods
+# Used for testing against other mods
 libs/*

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id "architectury-plugin" version "3.4-SNAPSHOT"
-	id "dev.architectury.loom" version "1.1-SNAPSHOT" apply false
+	id "dev.architectury.loom" version "1.2-SNAPSHOT" apply false
 	id "io.github.juuxel.loom-vineflower" version "1.+" apply false
 	id "io.github.pacifistmc.forgix" version "1.2.6"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ websocket = 1.5.3
 # Fabric Properties
 # https://fabricmc.net/develop
 # https://modrinth.com/mod/fabric-api
-fabric_api = 0.86.0+1.20.1
+fabric_api = 0.86.1+1.20.1
 fabric_loader_version = 0.14.21
 
 # Mod Dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,14 +15,16 @@ archives_base_name = figura
 assets_version = v1
 
 # Libraries
+# https://github.com/FiguraMC/luaj
+# https://github.com/TooTallNate/Java-WebSocket
 luaj = 3.0.6
-websocket = 1.5.3
+websocket = 1.5.4
 
 # Fabric Properties
 # https://fabricmc.net/develop
 # https://modrinth.com/mod/fabric-api
 fabric_api = 0.86.1+1.20.1
-fabric_loader_version = 0.14.21
+fabric_loader_version = 0.14.22
 
 # Mod Dependencies
 # https://modrinth.com/mod/modmenu
@@ -33,13 +35,13 @@ iris = 1.6.4+1.20
 
 # Forge Properties
 # https://files.minecraftforge.net/net/minecraftforge/forge
-forge_version = 1.20.1-47.1.37
+forge_version = 1.20.1-47.1.43
 
 # Quilt properties
 # https://lambdaurora.dev/tools/import_quilt.html
 # https://modrinth.com/mod/qsl
 quilt_loader_version = 0.20.0-beta.5
-quilt_fabric_api_version = 7.0.6+0.85.0-1.20.1
+quilt_fabric_api_version = 7.1.0+0.86.1-1.20.1
 
 # Extra properties
 run_on_quilt = false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,5 +2,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
1. Swaps the quotes with apostrophes instead although consider this a bit unnecessary of me,
2. The workflow will now check for a newer version of JDK 17 as github does not keep track of latest minor version, 
*(Default was 17.0.7 but we are on 17.0.8 now)*
3. The gradle wrapper jar will now also be checked to see if it's distribution source is properly signed,
4. This PR i will make will contain the last dependency patches i will be personally doing - LuaJ and websocket dependencies in properties file however are now also documented.