### PR TITLE
get_cooldown fixes

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/entity/PlayerAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/entity/PlayerAPI.java
@@ -4,6 +4,7 @@ import net.minecraft.client.multiplayer.PlayerInfo;
 import net.minecraft.client.resources.DefaultPlayerSkin;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.player.PlayerModelPart;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.scores.PlayerTeam;
 import org.figuramc.figura.lua.LuaNotNil;
@@ -13,6 +14,7 @@ import org.figuramc.figura.lua.ReadOnlyLuaTable;
 import org.figuramc.figura.lua.docs.LuaMethodDoc;
 import org.figuramc.figura.lua.docs.LuaMethodOverload;
 import org.figuramc.figura.lua.docs.LuaTypeDoc;
+import org.figuramc.figura.math.vector.FiguraVec3;
 import org.figuramc.figura.utils.EntityUtils;
 import org.luaj.vm2.LuaError;
 import org.luaj.vm2.LuaTable;
@@ -185,6 +187,22 @@ public class PlayerAPI extends LivingEntityAPI<Player> {
         map.put("collision_rule", team.getCollisionRule().name);
 
         return map;
+    }
+
+    @LuaWhitelist
+    @LuaMethodDoc(
+            overloads = {
+                    @LuaMethodOverload(
+                            argumentTypes = {ItemStack.class, Float.class},
+                            argumentNames = {"stack", "delta"}
+                    ),
+            },
+            value = "player.get_cooldown_percent"
+    )
+    public float getCoolDownPercent(@LuaNotNil ItemStack stack, Float delta) {
+        checkEntity();
+        if (delta == null) delta = 0f;
+        return this.entity.getCooldowns().getCooldownPercent(stack.getItem(), delta);
     }
 
     @Override

--- a/common/src/main/java/org/figuramc/figura/lua/api/world/ItemStackAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/world/ItemStackAPI.java
@@ -79,8 +79,8 @@ public class ItemStackAPI {
     }
 
     @LuaWhitelist
-    @LuaMethodDoc("itemstack.get_cooldown")
-    public int getCooldown() {
+    @LuaMethodDoc("itemstack.get_pop_time")
+    public int getPopTime() {
         return itemStack.getPopTime();
     }
 

--- a/common/src/main/resources/assets/figura/lang/en_us.json
+++ b/common/src/main/resources/assets/figura/lang/en_us.json
@@ -1081,6 +1081,7 @@
   "figura.docs.player.get_shoulder_entity": "Returns a table of the nbt of this entity left or right shoulder entity",
   "figura.docs.player.get_team_info": "Returns a table with information about the team of this player\nReturns nil if the player doesnt have a team",
   "figura.docs.player.get_ip_address": "Returns this player's IP address",
+  "figura.docs.player.get_cooldown_percent": "Returns the whether a given ItemStack has an active cool down as a percent from 0.0 to 1.0\nIf it has none, it returns 0.0\nTakes two parameters stack, and delta, delta offsets the cooldown's tick count by it, used for smoother animation.",
 
   "figura.docs.viewer": "An extension of the Player, used for the viewer only, meant as proxy to allow access to some host only functions",
 
@@ -1165,7 +1166,7 @@
   "figura.docs.itemstack.get_tag": "Gets a table of the NBT tags of this stack",
   "figura.docs.itemstack.get_count": "Gets the number of items in this stack",
   "figura.docs.itemstack.get_damage": "Gets the damage value of the item in this stack\nWorks on things like tools, or other things with a durability bar",
-  "figura.docs.itemstack.get_cooldown": "Gets the remaining cooldown on this item, in ticks",
+  "figura.docs.itemstack.get_pop_time": "Gets the item's animation bobbing time, in ticks. This value is used to move an item to the player when it is picked up",
   "figura.docs.itemstack.has_glint": "Returns true if this item glows with enchantment glint",
   "figura.docs.itemstack.get_tags": "Gets all the tags of this item as strings in a table",
   "figura.docs.itemstack.is_block_item": "Returns true if this item represents a block",


### PR DESCRIPTION
Renamed itemstack.get_cooldown to itemstack.get_poptime as that is the value that it really returns, also updated the docs to reflect that change.

Added a new method player.get_cooldown_percent in the PlayerAPI that returns the cooldown for a given stack.