### PR TITLE
Attempt 2 (to) fix  issue #50

### DIFF
--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/SkullBlockRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/SkullBlockRendererMixin.java
@@ -53,7 +53,7 @@ public abstract class SkullBlockRendererMixin implements BlockEntityRenderer<Sku
 
         // avatar
         Avatar localAvatar = avatar;
-        avatar = null;
+        SkullBlockRendererMixin.avatar = null;
 
         if (localAvatar == null || localAvatar.permissions.get(Permissions.CUSTOM_SKULL) == 0)
             return;
@@ -89,11 +89,24 @@ public abstract class SkullBlockRendererMixin implements BlockEntityRenderer<Sku
 
     @Override
     public boolean shouldRenderOffScreen(SkullBlockEntity blockEntity) {
-        return avatar == null ? BlockEntityRenderer.super.shouldRenderOffScreen(blockEntity) : avatar.permissions.get(Permissions.OFFSCREEN_RENDERING) == 1;
+    	// if we have an avatar, check permissions
+    	if(SkullBlockRendererMixin.avatar != null  && SkullBlockRendererMixin.avatar.permissions != null) {
+    		if(SkullBlockRendererMixin.avatar.permissions.get(Permissions.OFFSCREEN_RENDERING) == 1) {
+    		    return true;
+    		}else {
+    			return false;
+    		}
+    	}
+    	//no avatar present, default rendering used.  
+    	return BlockEntityRenderer.super.shouldRenderOffScreen(blockEntity);
     }
 
     @Inject(at = @At("HEAD"), method = "getRenderType")
     private static void getRenderType(SkullBlock.Type type, GameProfile profile, CallbackInfoReturnable<RenderType> cir) {
-        avatar = profile != null && profile.getId() != null ? AvatarManager.getAvatarForPlayer(profile.getId()) : null;
+    	// set skull owner's avatar to be associated with this skull.
+    	SkullBlockRendererMixin.avatar = null;
+    	if(profile != null && profile.getId() != null) {
+    		SkullBlockRendererMixin.avatar = AvatarManager.getAvatarForPlayer(profile.getId());
+    	}
     }
 }

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/SkullBlockRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/SkullBlockRendererMixin.java
@@ -88,15 +88,6 @@ public abstract class SkullBlockRendererMixin implements BlockEntityRenderer<Sku
 
     @Override
     public boolean shouldRenderOffScreen(SkullBlockEntity blockEntity) {
-    	// if we have an avatar, check permissions
-    	if(avatar != null  && avatar.permissions != null) {
-    		// if we have permissions to render, then we render, else we don't render.
-    		if(avatar.permissions.get(Permissions.OFFSCREEN_RENDERING) == 1) {
-    		    return true;
-    		}
-    		return false;
-    	}
-    	//no avatar present, default rendering used.  
     	return avatar == null || avatar.permissions == null ? BlockEntityRenderer.super.shouldRenderOffScreen(blockEntity) : avatar.permissions.get(Permissions.OFFSCREEN_RENDERING) == 1;
     }
 

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/SkullBlockRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/SkullBlockRendererMixin.java
@@ -93,11 +93,6 @@ public abstract class SkullBlockRendererMixin implements BlockEntityRenderer<Sku
 
     @Inject(at = @At("HEAD"), method = "getRenderType")
     private static void getRenderType(SkullBlock.Type type, GameProfile profile, CallbackInfoReturnable<RenderType> cir) {
-    	// reset avatar for skull
-    	avatar = null;
-    	// set skull owner's avatar to be associated with this skull.
-    	if(profile != null && profile.getId() != null) {
-    		avatar = AvatarManager.getAvatarForPlayer(profile.getId());
-    	}
+        avatar = (profile != null && profile.getId() != null) ? AvatarManager.getAvatarForPlayer(profile.getId()) : null;
     }
 }

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/SkullBlockRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/SkullBlockRendererMixin.java
@@ -53,6 +53,7 @@ public abstract class SkullBlockRendererMixin implements BlockEntityRenderer<Sku
 
         // avatar pointer incase avatar variable is set during render. (unlikely)
         Avatar localAvatar = avatar;
+        avatar = null;
 
         if (localAvatar == null || localAvatar.permissions.get(Permissions.CUSTOM_SKULL) == 0)
             return;
@@ -88,7 +89,8 @@ public abstract class SkullBlockRendererMixin implements BlockEntityRenderer<Sku
 
     @Override
     public boolean shouldRenderOffScreen(SkullBlockEntity blockEntity) {
-    	return avatar == null || avatar.permissions == null ? BlockEntityRenderer.super.shouldRenderOffScreen(blockEntity) : avatar.permissions.get(Permissions.OFFSCREEN_RENDERING) == 1;
+    	Avatar localAvatar = avatar; // avatar pointer incase avatar variable is set during render.
+    	return localAvatar == null || localAvatar.permissions == null ? BlockEntityRenderer.super.shouldRenderOffScreen(blockEntity) : localAvatar.permissions.get(Permissions.OFFSCREEN_RENDERING) == 1;
     }
 
     @Inject(at = @At("HEAD"), method = "getRenderType")

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/SkullBlockRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/SkullBlockRendererMixin.java
@@ -53,7 +53,6 @@ public abstract class SkullBlockRendererMixin implements BlockEntityRenderer<Sku
 
         // avatar
         Avatar localAvatar = avatar;
-        SkullBlockRendererMixin.avatar = null;
 
         if (localAvatar == null || localAvatar.permissions.get(Permissions.CUSTOM_SKULL) == 0)
             return;

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/SkullBlockRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/SkullBlockRendererMixin.java
@@ -51,7 +51,7 @@ public abstract class SkullBlockRendererMixin implements BlockEntityRenderer<Sku
         SkullBlockRendererAccessor.SkullRenderMode localMode = SkullBlockRendererAccessor.getRenderMode();
         SkullBlockRendererAccessor.setRenderMode(SkullBlockRendererAccessor.SkullRenderMode.OTHER);
 
-        // avatar
+        // avatar pointer incase avatar variable is set during render. (unlikely)
         Avatar localAvatar = avatar;
 
         if (localAvatar == null || localAvatar.permissions.get(Permissions.CUSTOM_SKULL) == 0)
@@ -89,12 +89,12 @@ public abstract class SkullBlockRendererMixin implements BlockEntityRenderer<Sku
     @Override
     public boolean shouldRenderOffScreen(SkullBlockEntity blockEntity) {
     	// if we have an avatar, check permissions
-    	if(SkullBlockRendererMixin.avatar != null  && SkullBlockRendererMixin.avatar.permissions != null) {
-    		if(SkullBlockRendererMixin.avatar.permissions.get(Permissions.OFFSCREEN_RENDERING) == 1) {
+    	if(avatar != null  && avatar.permissions != null) {
+    		// if we have permissions to render, then we render, else we don't render.
+    		if(avatar.permissions.get(Permissions.OFFSCREEN_RENDERING) == 1) {
     		    return true;
-    		}else {
-    			return false;
     		}
+    		return false;
     	}
     	//no avatar present, default rendering used.  
     	return BlockEntityRenderer.super.shouldRenderOffScreen(blockEntity);
@@ -102,10 +102,11 @@ public abstract class SkullBlockRendererMixin implements BlockEntityRenderer<Sku
 
     @Inject(at = @At("HEAD"), method = "getRenderType")
     private static void getRenderType(SkullBlock.Type type, GameProfile profile, CallbackInfoReturnable<RenderType> cir) {
+    	// reset avatar for skull
+    	avatar = null;
     	// set skull owner's avatar to be associated with this skull.
-    	SkullBlockRendererMixin.avatar = null;
     	if(profile != null && profile.getId() != null) {
-    		SkullBlockRendererMixin.avatar = AvatarManager.getAvatarForPlayer(profile.getId());
+    		avatar = AvatarManager.getAvatarForPlayer(profile.getId());
     	}
     }
 }

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/SkullBlockRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/SkullBlockRendererMixin.java
@@ -97,7 +97,7 @@ public abstract class SkullBlockRendererMixin implements BlockEntityRenderer<Sku
     		return false;
     	}
     	//no avatar present, default rendering used.  
-    	return BlockEntityRenderer.super.shouldRenderOffScreen(blockEntity);
+    	return avatar == null || avatar.permissions == null ? BlockEntityRenderer.super.shouldRenderOffScreen(blockEntity) : avatar.permissions.get(Permissions.OFFSCREEN_RENDERING) == 1;
     }
 
     @Inject(at = @At("HEAD"), method = "getRenderType")


### PR DESCRIPTION
This time i got 3  players who experienced the issue constantly because i myself couldn't recreate the issue.

The issue is a race condition with avatar being set to null in a render  at line 56 while at the  same time being called for permissions in line 92.
(The slower the computer  the  better for  recreation) 

i do not  know why this happens in the chunkbuilder. but i believe it is related to a bigger issue in the chunk thread builder renderer.
removing the nullset fixed all 3 players.  
This time the code is tested and found  to be working. closes #50 