### PR TITLE
Fixed world.getBlocks reusing block positions

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/world/WorldAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/world/WorldAPI.java
@@ -134,7 +134,10 @@ public class WorldAPI {
         if (!world.hasChunksAt(min, max))
             return list;
 
-        BlockPos.betweenClosedStream(min, max).forEach(blockPos -> list.add(new BlockStateAPI(world.getBlockState(blockPos), blockPos)));
+        BlockPos.betweenClosedStream(min, max).forEach(blockPos -> {
+            BlockPos pos = new BlockPos(blockPos);
+            list.add(new BlockStateAPI(world.getBlockState(pos), pos));
+        });
         return list;
     }
 


### PR DESCRIPTION
fixes a bug with world.getBlocks where each instance of BlockStateAPI returned by this method shares the same position