### PR TITLE
Add GitPod support, Patch Jitpack and Actions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 17

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,8 @@
+FROM gitpod/workspace-java-17
+USER gitpod
+
+SHELL ["/bin/bash", "-c"]
+
+RUN source ~/.sdkman/bin/sdkman-init.sh && \
+    sdk install java 17.0.8.1-tem && \
+    sdk use java 17.0.8.1-tem

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,11 @@
+image:
+  file: .gitpod.Dockerfile
+
+ports:
+  - port: 25565
+    onOpen: notify
+
+vscode:
+  extensions:
+    - richardwillis.vscode-gradle
+    - vscjava.vscode-java-pack

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,5 @@
-jdk:
-  - temurinjdk17
 before_install:
    - curl -s "https://get.sdkman.io" | bash
-   - source "$HOME/.sdkman/bin/sdkman-init.sh"
-   - sdk install java 17.0.8+7-tem
-   - sdk use java 17.0.8+7-tem
+   - source ~/.sdkman/bin/sdkman-init.sh
+   - sdk install java 17.0.8.1-tem
+   - sdk use java 17.0.8.1-tem


### PR DESCRIPTION
*(Resolves #17)*

This PR adds support for GitPod and allows such users to contribute to the Figura repository, The script is set up so that users are automatically given access to Temurin JDK 17 aswell as two extensions which are Microsoft's extension pack for Java and the Gradle extension pack,

Next, This PR fixes an issue where jitpack does not install the JDK properly due to typos being present,
Finally, The checkout step has been updated to v4 for actions.