### PR TITLE
Raycasting On - Fixes a crash with OffsetEye - Fixes not being able to hide the HUD on forge

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/nameplate/EntityNameplateCustomization.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/nameplate/EntityNameplateCustomization.java
@@ -121,7 +121,7 @@ public class EntityNameplateCustomization extends NameplateCustomization {
     @LuaWhitelist
     @LuaMethodDoc("nameplate_entity.get_background_color")
     public FiguraVec4 getBackgroundColor() {
-        return this.background == null ? null : ColorUtils.intToARGB(this.background);
+        return this.background == null ? null : ColorUtils.intToRGBA(this.background);
     }
 
     @LuaWhitelist
@@ -141,7 +141,7 @@ public class EntityNameplateCustomization extends NameplateCustomization {
     )
     public EntityNameplateCustomization setBackgroundColor(Object r, Double g, Double b, Double a) {
         FiguraVec4 vec = LuaUtils.parseVec4("setBackgroundColor", r, g, b, a, 0, 0, 0,  Minecraft.getInstance().options.getBackgroundOpacity(0.25f));
-        this.background = ColorUtils.rgbaToIntARGB(vec);
+        this.background = ColorUtils.rgbaToInt(vec);
         return this;
     }
 

--- a/common/src/main/java/org/figuramc/figura/lua/api/world/WorldAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/world/WorldAPI.java
@@ -371,7 +371,29 @@ public class WorldAPI {
         }
     }
 
-    // @LuaWhitelist
+    @LuaWhitelist
+    @LuaMethodDoc(
+            overloads = {
+                    @LuaMethodOverload(
+                    argumentTypes = {Boolean.class, FiguraVec3.class, FiguraVec3.class},
+                    argumentNames = {"fluid", "start", "end"}
+                    ),
+                    @LuaMethodOverload(
+                            argumentTypes = {Boolean.class, Double.class, Double.class, Double.class, FiguraVec3.class},
+                            argumentNames = {"fluid", "startX", "startY", "startZ", "end"}
+                    ),
+                    @LuaMethodOverload(
+                            argumentTypes = {Boolean.class, FiguraVec3.class, Double.class, Double.class, Double.class},
+                            argumentNames = {"fluid", "start", "endX", "endY", "endZ"}
+                    ),
+                    @LuaMethodOverload(
+                            argumentTypes = {Boolean.class, Double.class, Double.class, Double.class, Double.class, Double.class, Double.class},
+                            argumentNames = {"fluid", "startX", "startY", "startZ", "endX", "endY", "endZ"}
+                    )
+                }
+            ,
+            value = "world.raycast_block"
+    )
     public HashMap<String, Object> raycastBlock(boolean fluid, Object x, Object y, Double z, Object w, Double t, Double h) {
         FiguraVec3 start, end;
 
@@ -392,7 +414,29 @@ public class WorldAPI {
         return map;
     }
 
-    // @LuaWhitelist
+    @LuaWhitelist
+    @LuaMethodDoc(
+            overloads = {
+                    @LuaMethodOverload(
+                            argumentTypes = {FiguraVec3.class, FiguraVec3.class},
+                            argumentNames = {"start", "end"}
+                    ),
+                    @LuaMethodOverload(
+                            argumentTypes = {Double.class, Double.class, Double.class, FiguraVec3.class},
+                            argumentNames = {"startX", "startY", "startZ", "end"}
+                    ),
+                    @LuaMethodOverload(
+                            argumentTypes = {FiguraVec3.class, Double.class, Double.class, Double.class},
+                            argumentNames = {"start", "endX", "endY", "endZ"}
+                    ),
+                    @LuaMethodOverload(
+                            argumentTypes = {Double.class, Double.class, Double.class, Double.class, Double.class, Double.class},
+                            argumentNames = {"startX", "startY", "startZ", "endX", "endY", "endZ"}
+                    )
+            }
+            ,
+            value = "world.raycast_entity"
+    )
     public HashMap<String, Object> raycastEntity(Object x, Object y, Double z, Object w, Double t, Double h) {
         FiguraVec3 start, end;
 

--- a/common/src/main/java/org/figuramc/figura/math/vector/FiguraVec2.java
+++ b/common/src/main/java/org/figuramc/figura/math/vector/FiguraVec2.java
@@ -548,7 +548,7 @@ public class FiguraVec2 extends FiguraVector<FiguraVec2, FiguraMat2> {
             else if (b instanceof Number d)
                 return vec.scaled(d.doubleValue());
             else if (b instanceof FiguraMat2 mat)
-                return vec.transform(mat);
+                return vec.copy().transform(mat);
         } else if (a instanceof Number d && b instanceof FiguraVec2 vec) {
             return (vec.scaled(d.doubleValue()));
         }

--- a/common/src/main/java/org/figuramc/figura/math/vector/FiguraVec3.java
+++ b/common/src/main/java/org/figuramc/figura/math/vector/FiguraVec3.java
@@ -621,7 +621,7 @@ public class FiguraVec3 extends FiguraVector<FiguraVec3, FiguraMat3> {
             else if (b instanceof Number d)
                 return vec.scaled(d.doubleValue());
             else if (b instanceof FiguraMat3 mat)
-                return vec.transform(mat);
+                return vec.copy().transform(mat);
         } else if (a instanceof Number d && b instanceof FiguraVec3 vec) {
             return (vec.scaled(d.doubleValue()));
         }

--- a/common/src/main/java/org/figuramc/figura/math/vector/FiguraVec4.java
+++ b/common/src/main/java/org/figuramc/figura/math/vector/FiguraVec4.java
@@ -588,7 +588,7 @@ public class FiguraVec4 extends FiguraVector<FiguraVec4, FiguraMat4> {
             else if (b instanceof Number d)
                 return vec.scaled(d.doubleValue());
             else if (b instanceof FiguraMat4 mat)
-                return vec.transform(mat);
+                return vec.copy().transform(mat);
         } else if (a instanceof Number d && b instanceof FiguraVec4 vec) {
             return (vec.scaled(d.doubleValue()));
         }

--- a/common/src/main/java/org/figuramc/figura/mixin/EntityMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/EntityMixin.java
@@ -14,11 +14,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(Entity.class)
 public class EntityMixin {
 
-    @Inject(method = "getEyePosition()Lnet/minecraft/world/phys/Vec3;", at = @At("RETURN"), cancellable = true)
-    private void getEyePosition(CallbackInfoReturnable<Vec3> cir) {
-        figura$offsetEyePos(cir);
-    }
-
     @Inject(method = "getEyePosition(F)Lnet/minecraft/world/phys/Vec3;", at = @At("RETURN"), cancellable = true)
     private void getEyePosition(float tickDelta, CallbackInfoReturnable<Vec3> cir) {
         figura$offsetEyePos(cir);

--- a/common/src/main/resources/assets/figura/lang/en_us.json
+++ b/common/src/main/resources/assets/figura/lang/en_us.json
@@ -1798,5 +1798,7 @@
   "figura.docs.world.new_item": "Parses and create a new ItemStack from the given string\nA count and damage can be given, to be applied on this itemstack",
   "figura.docs.world.exists": "Checks whether or not a world currently exists\nThis will almost always be true, but might be false on some occasions such as while travelling between dimensions",
   "figura.docs.world.get_build_height": "Returns the minimum and maximum build height of the world, as varargs",
-  "figura.docs.world.get_spawn_point": "Returns a vector with the coordinates of the world spawn"
+  "figura.docs.world.get_spawn_point": "Returns a vector with the coordinates of the world spawn",
+  "figura.docs.world.raycast_entity": "Raycasts an Entity in the world, returns a map containing the entity and it's position.",
+  "figura.docs.world.raycast_block": "Raycasts a Block in the world, returns a map containing the block and it's position."
 }

--- a/forge/src/main/java/org/figuramc/figura/forge/FiguraModClientForge.java
+++ b/forge/src/main/java/org/figuramc/figura/forge/FiguraModClientForge.java
@@ -1,14 +1,22 @@
 package org.figuramc.figura.forge;
 
 import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.entity.Entity;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RegisterClientReloadListenersEvent;
 import net.minecraftforge.client.event.RegisterGuiOverlaysEvent;
 import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
+import net.minecraftforge.client.event.RenderGuiOverlayEvent;
+import net.minecraftforge.client.gui.overlay.IGuiOverlay;
+import net.minecraftforge.client.gui.overlay.NamedGuiOverlay;
+import net.minecraftforge.client.gui.overlay.VanillaGuiOverlay;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import org.figuramc.figura.FiguraMod;
+import org.figuramc.figura.avatar.Avatar;
+import org.figuramc.figura.avatar.AvatarManager;
 import org.figuramc.figura.config.forge.ModConfig;
 import org.figuramc.figura.gui.forge.GuiOverlay;
 import org.figuramc.figura.gui.forge.GuiUnderlay;
@@ -37,6 +45,22 @@ public class FiguraModClientForge extends FiguraMod {
     public static void registerOverlays(RegisterGuiOverlaysEvent event) {
         event.registerAboveAll("figura_overlay", new GuiOverlay());
         event.registerBelowAll("figura_underlay", new GuiUnderlay());
+    }
+
+    private static final List<NamedGuiOverlay> vanillaOverlays = new ArrayList<>() {{
+        for (VanillaGuiOverlay overlay : VanillaGuiOverlay.values()) {
+            this.add(overlay.type());
+        }
+    }};
+    @SubscribeEvent
+    public static void cancelVanillaOverlays(RenderGuiOverlayEvent.Pre event) {
+        if (vanillaOverlays.contains(event.getOverlay())) {
+            Entity entity = Minecraft.getInstance().getCameraEntity();
+            Avatar avatar = entity == null ? null : AvatarManager.getAvatar(entity);
+            if (avatar != null && avatar.luaRuntime != null && !avatar.luaRuntime.renderer.renderHUD) {
+                event.setCanceled(true);
+            }
+        }
     }
 
     @SubscribeEvent


### PR DESCRIPTION
This just makes raycasting accessible in the WorldAPI
This PR also removes a cheaty mixin that was unnecessary that could let the user crash their single player game.
 Fixes: 
- Hud hiding not working on forge
- Vector Operator *: Multiplying by a Matrix modifies the vector instead of copying it.
- EntityNameplate:getBackgroundColor(): Returns a barg vector instead of an rgba vector.