### PR TITLE
Add `world.isChunkLoaded()` to check if chunks are loaded

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/world/WorldAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/world/WorldAPI.java
@@ -91,8 +91,29 @@ public class WorldAPI {
         BlockPos blockPos = pos.asBlockPos();
         Level world = getCurrentWorld();
         if (!world.hasChunkAt(blockPos))
-            return new BlockStateAPI(Blocks.AIR.defaultBlockState(), blockPos);
+            return new BlockStateAPI(Blocks.VOID_AIR.defaultBlockState(), blockPos);
         return new BlockStateAPI(world.getBlockState(blockPos), blockPos);
+    }
+    @SuppressWarnings("deprecation")
+    @LuaWhitelist
+    @LuaMethodDoc(
+        overloads = {
+            @LuaMethodOverload(
+                argumentTypes = FiguraVec3.class,
+                argumentNames = "pos"
+            ),
+            @LuaMethodOverload(
+                argumentTypes = {Double.class, Double.class, Double.class},
+                argumentNames = {"x", "y", "z"}
+            )
+        },
+        value = "world.is_chunk_loaded"
+    )
+    public static boolean isChunkLoaded(Object x, Double y, Double z) {
+        FiguraVec3 pos = LuaUtils.parseVec3("getBlockState", x, y, z);
+        BlockPos blockPos = pos.asBlockPos();
+        Level world = getCurrentWorld();
+        return world.hasChunkAt(blockPos);
     }
 
     @SuppressWarnings("deprecation")

--- a/common/src/main/resources/assets/figura/lang/en_us.json
+++ b/common/src/main/resources/assets/figura/lang/en_us.json
@@ -1781,7 +1781,8 @@
 
   "figura.docs.world": "A global API dedicated to reading information from the Minecraft world\nAccessed using the name \"world\"",
   "figura.docs.world.get_biome": "Gets the Biome located at the given position",
-  "figura.docs.world.get_block_state": "Gets the BlockState of the block at the given position",
+  "figura.docs.world.get_block_state": "Gets the BlockState of the block at the given position\nIf it is not loaded, returns void_air",
+  "figura.docs.world.is_loaded": "Checks if the position has a chunk loaded\nIf you need to access the block, it's usually more efficient to use getBlockState()",
   "figura.docs.world.get_blocks": "Gets a list of all BlockStates in the specified area\nThe maximum area size is 8 x 8 x 8",
   "figura.docs.world.get_redstone_power": "Gets the redstone power level of the block at the given position",
   "figura.docs.world.get_strong_redstone_power": "Gets the direct redstone power level of the block at the given position",


### PR DESCRIPTION
Also makes it so that `world:getBlockState()` properly returns VOID_AIR instead of AIR, and documents that so nobody can change it

Cherrypicked-from: 421dbc43d88ad62725e439b8f94f769991f30625

---
Replace-PR: #88
Request-Review: @UnlikePaladin 