### PR TITLE
Added re-colorable emojis

### DIFF
--- a/common/src/main/java/org/figuramc/figura/commands/EmojiListCommand.java
+++ b/common/src/main/java/org/figuramc/figura/commands/EmojiListCommand.java
@@ -9,6 +9,7 @@ import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
 import org.figuramc.figura.font.EmojiContainer;
 import org.figuramc.figura.font.EmojiUnicodeLookup;
 import org.figuramc.figura.font.Emojis;
@@ -85,7 +86,7 @@ class EmojiListCommand {
                     }
                 }
                 msg.append(literal("\ncodepoint: " + unicode.codePointAt(0)).withStyle(ChatFormatting.GRAY));
-                comp.append(Emojis.getEmoji(aliases[0], msg));
+                comp.append(Emojis.getEmoji(aliases[0], Style.EMPTY, msg));
             }
         });
 

--- a/common/src/main/java/org/figuramc/figura/font/EmojiMetadata.java
+++ b/common/src/main/java/org/figuramc/figura/font/EmojiMetadata.java
@@ -9,17 +9,38 @@ public class EmojiMetadata {
     public final int frames;
     public final int frameTime;
     public final int width;
+    public final int defaultColor;
+    public final boolean canBeColored;
     private int frameTimer;
     private int curFrame;
+
+    public EmojiMetadata(int frames, int frameTime, int width, int defaultColor) {
+        this.frames = frames;
+        this.frameTime = frameTime;
+        this.width = width;
+        this.defaultColor = defaultColor;
+        this.canBeColored = true;
+    }
 
     public EmojiMetadata(int frames, int frameTime, int width) {
         this.frames = frames;
         this.frameTime = frameTime;
         this.width = width;
+        this.defaultColor = -1;
+        this.canBeColored = false;
     }
 
-    public EmojiMetadata(JsonObject entry) {
-        this(entry.get(JSON_KEY_FRAMES).getAsInt(), entry.get(JSON_KEY_FRAME_TIME).getAsInt(), JsonUtils.getIntOrDefault(entry, JSON_KEY_WIDTH, 8));
+    public static EmojiMetadata fromJson(JsonObject entry) {
+        int frameCount = JsonUtils.getIntOrDefault(entry, JSON_KEY_FRAMES, 1);
+        int frameTime = JsonUtils.getIntOrDefault(entry, JSON_KEY_FRAME_TIME, 1);
+        int width = JsonUtils.getIntOrDefault(entry, JSON_KEY_WIDTH, 8);
+
+        if (entry.has("color")) {
+            String hexColor = entry.get(JSON_KEY_DEFAULT_COLOR).getAsString();
+            return new EmojiMetadata(frameCount, frameTime, width, Integer.parseInt(hexColor, 16));
+        }
+
+        return new EmojiMetadata(frameCount, frameTime, width);
     }
 
     public void tickAnimation() {

--- a/common/src/main/java/org/figuramc/figura/font/EmojiUnicodeLookup.java
+++ b/common/src/main/java/org/figuramc/figura/font/EmojiUnicodeLookup.java
@@ -57,10 +57,6 @@ public class EmojiUnicodeLookup {
         return shortcutLookup.getOrDefault(shortcut, null);
     }
 
-
-
-
-
     public Collection<EmojiMetadata> metadataValues() {
         return metadataLookup.values();
     }

--- a/common/src/main/java/org/figuramc/figura/font/Emojis.java
+++ b/common/src/main/java/org/figuramc/figura/font/Emojis.java
@@ -15,7 +15,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.function.Function;
 
 public class Emojis {
 
@@ -180,7 +179,7 @@ public class Emojis {
                         for (String shortcut : shortcuts) {
                             if (s.startsWith(shortcut)) {
                                 s = s.substring(shortcut.length());
-                                result.append(SHORTCUT_LOOKUP.get(shortcut).getShortcutComponent(shortcut));
+                                result.append(SHORTCUT_LOOKUP.get(shortcut).getShortcutComponent(shortcut, style));
                                 anyFound = true;
                                 break;
                             }
@@ -198,25 +197,26 @@ public class Emojis {
             }
             // odd: format and append emoji
             else {
-                appendEmoji(result, s, Emojis::getEmoji);
+                appendEmoji(result, s, style);
             }
         }
 
         return result;
     }
 
-    private static void appendEmoji(MutableComponent result, String s, Function<String, Component> converter) {
-        Component emoji = converter.apply(s);
+    private static void appendEmoji(MutableComponent result, String alias, Style style) {
+        MutableComponent emoji = Emojis.getEmoji(alias, style);
+        
         if (emoji != null) {
             result.append(emoji);
         } else {
-            result.append(DELIMITER + s + DELIMITER);
+            result.append(DELIMITER + alias + DELIMITER);
         }
     }
 
-    public static Component getEmoji(String emojiAlias) {
+    public static MutableComponent getEmoji(String emojiAlias, Style style) {
         for (EmojiContainer container : EMOJIS.values()) {
-            Component emoji = container.getEmojiComponent(emojiAlias);
+            MutableComponent emoji = container.getEmojiComponent(emojiAlias, style);
             if (emoji != null) {
                 return emoji;
             }
@@ -224,9 +224,9 @@ public class Emojis {
         return null;
     }
 
-    public static Component getEmoji(String emojiAlias, MutableComponent hover) {
+    public static MutableComponent getEmoji(String emojiAlias, Style style, MutableComponent hover) {
         for (EmojiContainer container : EMOJIS.values()) {
-            Component emoji = container.getEmojiComponent(emojiAlias, hover);
+            MutableComponent emoji = container.getEmojiComponent(emojiAlias, hover, style);
             if (emoji != null) {
                 return emoji;
             }

--- a/common/src/main/java/org/figuramc/figura/mixin/font/BakedGlyphMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/font/BakedGlyphMixin.java
@@ -49,7 +49,7 @@ public abstract class BakedGlyphMixin implements BakedGlyphAccessor {
 
     @Inject(method = "render", at = @At("HEAD"), cancellable = true)
     public void render(boolean italic, float x, float y, Matrix4f matrix, VertexConsumer vertexConsumer, float red, float green, float blue, float alpha, int light, CallbackInfo ci) {
-        if (figura$metadata == null) return;
+        if (figura$metadata == null || figura$metadata.frames < 2) return;
 
         float h = this.up - 3.0f;
         float j = this.down - 3.0f;

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/SignRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/SignRendererMixin.java
@@ -1,20 +1,47 @@
 package org.figuramc.figura.mixin.render.renderers;
 
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.blockentity.SignRenderer;
+import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.FormattedText;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
+import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.level.block.entity.SignText;
 import org.figuramc.figura.config.Configs;
 import org.figuramc.figura.font.Emojis;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(SignRenderer.class)
 public class SignRendererMixin {
 
+    @Unique private SignText figura$signText;
+
+    @Inject(method = "renderSignText", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/entity/SignText;getRenderMessages(ZLjava/util/function/Function;)[Lnet/minecraft/util/FormattedCharSequence;", shift = At.Shift.BEFORE))
+    private void captureSignText(BlockPos pos, SignText text, PoseStack matrices, MultiBufferSource vertexConsumers, int light, int lineHeight, int lineWidth, boolean front, CallbackInfo ci) {
+        figura$signText = text;
+    }
+
     // method_45799 corresponds to fabric intermediary, lambda$renderSignText$2 is the unmapped OF name, m_276705_ is the SRG name for Forge
     @ModifyArg(method = {"method_45799", "lambda$renderSignText$2", "m_276705_"}, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Font;split(Lnet/minecraft/network/chat/FormattedText;I)Ljava/util/List;", remap = true), remap = false)
     private FormattedText modifyText(FormattedText charSequence) {
-        return Configs.EMOJIS.value > 0 && charSequence instanceof Component text ? Emojis.applyEmojis(text) : charSequence;
+        if (!(Configs.EMOJIS.value > 0 && charSequence instanceof Component text)) return charSequence;
+
+        MutableComponent test = MutableComponent.create(text.getContents());
+        if (figura$signText.getColor() == DyeColor.BLACK) {
+            test = test.withStyle(Style.EMPTY);
+        } else {
+            test = test.withStyle(Style.EMPTY.withColor(figura$signText.getColor().getTextColor()));
+        }
+
+
+        return Emojis.applyEmojis(test);
     }
 }

--- a/common/src/main/java/org/figuramc/figura/utils/JsonUtils.java
+++ b/common/src/main/java/org/figuramc/figura/utils/JsonUtils.java
@@ -30,6 +30,13 @@ public class JsonUtils {
         return fallback;
     }
 
+    public static boolean getBooleanOrDefault(JsonObject object, String fieldName, boolean fallback) {
+        if (validate(object, fieldName, JsonElement::isJsonPrimitive)) {
+            return object.get(fieldName).getAsBoolean();
+        }
+        return fallback;
+    }
+
     public static LuaValue asLuaValue(JsonElement value) {
         if (value.isJsonPrimitive()) {
             JsonPrimitive p = value.getAsJsonPrimitive();


### PR DESCRIPTION
Emojis can now include the field "color", which takes a hex string. When this field is present, it allows the emoji to be recolored, and when no color is given, it uses it's default, given by the "color" field.