### PR TITLE
Trident Parent Type And Event

### DIFF
--- a/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
+++ b/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
@@ -375,6 +375,12 @@ public class Avatar {
         return isCancelled(result);
     }
 
+    public boolean tridentRenderEvent(float delta, EntityAPI<?> trident) {
+        Varargs result = null;
+        if (loaded) result = run("TRIDENT_RENDER", render, delta, trident);
+        return isCancelled(result);
+    }
+
     public boolean itemRenderEvent(ItemStackAPI item, String mode, FiguraVec3 pos, FiguraVec3 rot, FiguraVec3 scale, boolean leftHanded, PoseStack stack, MultiBufferSource bufferSource, int light, int overlay) {
         Varargs result = loaded ? run("ITEM_RENDER", render, item, mode, pos, rot, scale, leftHanded) : null;
         if (result == null)
@@ -762,6 +768,28 @@ public class Avatar {
 
         renderer.setupRenderer(
                 PartFilterScheme.ARROW, bufferSource, stack,
+                delta, light, 1f, OverlayTexture.NO_OVERLAY,
+                false, false
+        );
+
+        int comp = renderer.renderSpecialParts();
+
+        stack.popPose();
+        return comp > 0;
+    }
+
+    public boolean renderTrident(PoseStack stack, MultiBufferSource bufferSource, float delta, int light) {
+        if (renderer == null || !loaded)
+            return false;
+
+        stack.pushPose();
+        Quaternionf quaternionf = Axis.XP.rotationDegrees(135f);
+        Quaternionf quaternionf2 = Axis.YP.rotationDegrees(-90f);
+        quaternionf.mul(quaternionf2);
+        stack.mulPose(quaternionf);
+
+        renderer.setupRenderer(
+                PartFilterScheme.TRIDENT, bufferSource, stack,
                 delta, light, 1f, OverlayTexture.NO_OVERLAY,
                 false, false
         );

--- a/common/src/main/java/org/figuramc/figura/lua/api/event/EventsAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/event/EventsAPI.java
@@ -73,6 +73,9 @@ public class EventsAPI {
     @LuaFieldDoc("events.arrow_render")
     public final LuaEvent ARROW_RENDER = new LuaEvent();
     @LuaWhitelist
+    @LuaFieldDoc("events.trident_render")
+    public final LuaEvent TRIDENT_RENDER = new LuaEvent();
+    @LuaWhitelist
     @LuaFieldDoc("events.item_render")
     public final LuaEvent ITEM_RENDER = new LuaEvent();
     @LuaWhitelist
@@ -100,6 +103,7 @@ public class EventsAPI {
             put("CHAR_TYPED", CHAR_TYPED);
             put("USE_ITEM", USE_ITEM);
             put("ARROW_RENDER", ARROW_RENDER);
+            put("TRIDENT_RENDER", TRIDENT_RENDER);
             put("ITEM_RENDER", ITEM_RENDER);
             put("ON_PLAY_SOUND", ON_PLAY_SOUND);
             put("RESOURCE_RELOAD", RESOURCE_RELOAD);

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/TridentRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/TridentRendererMixin.java
@@ -1,0 +1,52 @@
+package org.figuramc.figura.mixin.render.renderers;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.ThrownTridentRenderer;
+import net.minecraft.client.renderer.entity.EntityRenderer;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.projectile.ThrownTrident;
+import org.figuramc.figura.FiguraMod;
+import org.figuramc.figura.avatar.Avatar;
+import org.figuramc.figura.avatar.AvatarManager;
+import org.figuramc.figura.lua.api.entity.EntityAPI;
+import org.figuramc.figura.permissions.Permissions;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ThrownTridentRenderer.class)
+public abstract class TridentRendererMixin<T extends ThrownTrident > extends EntityRenderer<T> {
+
+    protected TridentRendererMixin(EntityRendererProvider.Context ctx) {
+        super(ctx);
+    }
+
+    @Inject(at = @At(value = "INVOKE", shift = At.Shift.AFTER, target = "Lcom/mojang/blaze3d/vertex/PoseStack;pushPose()V"), method = "render(Lnet/minecraft/world/entity/projectile/ThrownTrident;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V", cancellable = true)
+    private void render(T abstractTrident, float yaw, float tickDelta, PoseStack poseStack, MultiBufferSource multiBufferSource, int light, CallbackInfo ci) {
+        Entity owner = abstractTrident.getOwner();
+        if (owner == null)
+            return;
+
+        Avatar avatar = AvatarManager.getAvatar(owner);
+        if (avatar == null || avatar.permissions.get(Permissions.VANILLA_MODEL_EDIT) == 0)
+            return;
+
+        FiguraMod.pushProfiler(FiguraMod.MOD_ID);
+        FiguraMod.pushProfiler(avatar);
+        FiguraMod.pushProfiler("tridentRender");
+
+        FiguraMod.pushProfiler("event");
+        boolean bool = avatar.tridentRenderEvent(tickDelta, EntityAPI.wrap(abstractTrident));
+
+        FiguraMod.popPushProfiler("render");
+        if (bool || avatar.renderTrident(poseStack, multiBufferSource, tickDelta, light)) {
+            poseStack.popPose();
+            ci.cancel();
+        }
+
+        FiguraMod.popProfiler(4);
+    }
+}

--- a/common/src/main/java/org/figuramc/figura/model/ParentType.java
+++ b/common/src/main/java/org/figuramc/figura/model/ParentType.java
@@ -31,6 +31,7 @@ public enum ParentType {
     Skull(true, false, "SKULL", "☠"),
     Portrait(true, false, "PORTRAIT"),
     Arrow(true, false, "ARROW"),
+    Trident(true, false, "TRIDENT"),
     Item(true, false, "ITEM"),
 
     // Held items, birds, n stuff

--- a/common/src/main/java/org/figuramc/figura/model/rendering/PartFilterScheme.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendering/PartFilterScheme.java
@@ -24,6 +24,7 @@ public enum PartFilterScheme {
     SKULL(false, SchemeFunction.onlyThisSeparate(ParentType.Skull), ParentType.Skull),
     PORTRAIT(false, SchemeFunction.onlyThisSeparate(ParentType.Portrait), ParentType.Portrait),
     ARROW(false, SchemeFunction.onlyThisSeparate(ParentType.Arrow), ParentType.Arrow),
+    TRIDENT(false, SchemeFunction.onlyThisSeparate(ParentType.Trident), ParentType.Trident),
     ITEM(false, SchemeFunction.onlyThisSeparate(ParentType.Item), ParentType.Item),
 
     PIVOTS(false, SchemeFunction.onlyPivotsAndCancelOnSeparate(), ParentType.HelmetItemPivot);

--- a/common/src/main/resources/figura-common.mixins.json
+++ b/common/src/main/resources/figura-common.mixins.json
@@ -4,6 +4,7 @@
   "package": "org.figuramc.figura.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "render.renderers.TridentRendererMixin"
   ],
   "client": [
     "BiomeAccessor",
@@ -19,6 +20,7 @@
     "MinecraftMixin",
     "ReloadableResourceManagerMixin",
     "SkullBlockEntityAccessor",
+    "TextDisplayMixin",
     "font.BakedGlyphMixin",
     "font.BitmapGlyphMixin",
     "font.FontSetMixin",
@@ -58,7 +60,6 @@
     "render.MissingTextureAtlasSpriteAccessor",
     "render.ModelManagerAccessor",
     "render.PlayerModelMixin",
-    "TextDisplayMixin",
     "render.TextureAtlasAccessor",
     "render.TextureManagerAccessor",
     "render.layers.CapeLayerMixin",
@@ -72,6 +73,7 @@
     "render.layers.items.ItemInHandLayerMixin",
     "render.layers.items.PlayerItemInHandLayerMixin",
     "render.renderers.ArrowRendererMixin",
+    "render.renderers.TridentRendererMixin",
     "render.renderers.BlockEntityWithoutLevelRendererMixin",
     "render.renderers.EntityRendererMixin",
     "render.renderers.HandRenderSelectionAccessor",

--- a/common/src/main/resources/figura-common.mixins.json
+++ b/common/src/main/resources/figura-common.mixins.json
@@ -3,9 +3,7 @@
   "minVersion": "0.8",
   "package": "org.figuramc.figura.mixin",
   "compatibilityLevel": "JAVA_17",
-  "mixins": [
-    "render.renderers.TridentRendererMixin"
-  ],
+  "mixins": [],
   "client": [
     "BiomeAccessor",
     "BlockBehaviourAccessor",


### PR DESCRIPTION
Adds a new ParenType `TRIDENT` and a `TRIDENT_RENDER` event, both of which work exactly like the `ARROW` and `ARROW_RENDER` events, except that the model is not being rotated into the direction it is flying. (Which I think `ARROW` ParentType does do, right?)

Here is an example Avatar that uses these features to replace the vanilla Trident model and also rotates the model to face into the flying direction: [Direct Link](https://cdn.discordapp.com/attachments/1152237863468007454/1152237900608585749/trident-example-avatar.zip) or [Discord Message](https://discord.com/channels/1129805506354085959/1152237863468007454/1152237901053165568)