### PR TITLE
Update dependencies, Fix workflow, Comment for Quilt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,6 @@ jobs:
           check-latest: true
       - name: Build using Gradle
         run: ./gradlew build
-      - name: Merge Fabric and Forge JARs
-        run: ./gradlew mergeJars
       - name: Upload Fabric artifacts to GitHub
         uses: actions/upload-artifact@v3
         with:
@@ -29,8 +27,8 @@ jobs:
         with:
           name: Forge-Artifacts
           path: forge/build/libs/
-      - name: Upload Merged JAR to GitHub
+      - name: Upload NeoForge artifacts to GitHub
         uses: actions/upload-artifact@v3
         with:
-          name: Merged-JAR
-          path: Merged/
+          name: Forge-Artifacts
+          path: forge/build/libs/

--- a/forge/src/main/resources/pack.mcmeta
+++ b/forge/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
     "description": "Figura Resources",
-    "pack_format": 15
+    "pack_format": 18
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ quilt_fabric_api_version = 7.4.0+0.90.0-1.20.1
 
 # NeoForge Properties
 # https://neoforged.net
-neoforge_version = 20.2.62-beta
+neoforge_version = 20.2.64-beta
 
 # Extra properties
 run_on_quilt = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ quilt_fabric_api_version = 7.4.0+0.90.0-1.20.1
 
 # NeoForge Properties
 # https://neoforged.net
-neoforge_version = 20.2.86-beta
+neoforge_version = 20.2.86
 
 # Extra properties
 run_on_quilt = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,30 +23,32 @@ websocket = 1.5.4
 # Fabric Properties
 # https://fabricmc.net/develop
 # https://modrinth.com/mod/fabric-api
-fabric_api = 0.89.3+1.20.2
-fabric_loader_version = 0.14.22
+fabric_api = 0.90.7+1.20.2
+fabric_loader_version = 0.14.24
 
 # Mod Dependencies
 # https://modrinth.com/mod/modmenu
 # https://modrinth.com/mod/iris
 # https://modrinth.com/mod/immediatelyfast
 modmenu = 8.0.0
-iris = 1.6.9+1.20.2
-immediately_fast = 1.2.6+1.20.2
+iris = 1.6.10+1.20.2
+immediately_fast = 1.2.7+1.20.2
 
 # Forge Properties
 # https://files.minecraftforge.net/net/minecraftforge/forge
-forge_version = 1.20.2-48.0.13
+forge_version = 1.20.2-48.0.40
 
 # Quilt properties
 # https://lambdaurora.dev/tools/import_quilt.html
 # https://modrinth.com/mod/qsl
-quilt_loader_version = 0.20.0-beta.5
-quilt_fabric_api_version = 7.1.0+0.86.1-1.20.1
+#
+# (Notice: Quilt does not have support for 1.20.2 yet)
+quilt_loader_version = 0.21.2
+quilt_fabric_api_version = 7.4.0+0.90.0-1.20.1
 
 # NeoForge Properties
 # https://neoforged.net
-neoforge_version = 20.2.56-beta
+neoforge_version = 20.2.62-beta
 
 # Extra properties
 run_on_quilt = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,12 +31,12 @@ fabric_loader_version = 0.14.25
 # https://modrinth.com/mod/iris
 # https://modrinth.com/mod/immediatelyfast
 modmenu = 8.0.0
-iris = 1.6.10+1.20.2
+iris = 1.6.11+1.20.2
 immediately_fast = 1.2.7+1.20.2
 
 # Forge Properties
 # https://files.minecraftforge.net/net/minecraftforge/forge
-forge_version = 1.20.2-48.0.49
+forge_version = 1.20.2-48.1.0
 
 # Quilt properties
 # https://lambdaurora.dev/tools/import_quilt.html
@@ -48,7 +48,7 @@ quilt_fabric_api_version = 7.4.0+0.90.0-1.20.1
 
 # NeoForge Properties
 # https://neoforged.net
-neoforge_version = 20.2.80-beta
+neoforge_version = 20.2.86-beta
 
 # Extra properties
 run_on_quilt = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,8 +23,8 @@ websocket = 1.5.4
 # Fabric Properties
 # https://fabricmc.net/develop
 # https://modrinth.com/mod/fabric-api
-fabric_api = 0.90.7+1.20.2
-fabric_loader_version = 0.14.24
+fabric_api = 0.91.1+1.20.2
+fabric_loader_version = 0.14.25
 
 # Mod Dependencies
 # https://modrinth.com/mod/modmenu
@@ -36,19 +36,19 @@ immediately_fast = 1.2.7+1.20.2
 
 # Forge Properties
 # https://files.minecraftforge.net/net/minecraftforge/forge
-forge_version = 1.20.2-48.0.40
+forge_version = 1.20.2-48.0.49
 
 # Quilt properties
 # https://lambdaurora.dev/tools/import_quilt.html
 # https://modrinth.com/mod/qsl
 #
 # (Notice: Quilt does not have support for 1.20.2 yet)
-quilt_loader_version = 0.21.2
+quilt_loader_version = 0.22.0
 quilt_fabric_api_version = 7.4.0+0.90.0-1.20.1
 
 # NeoForge Properties
 # https://neoforged.net
-neoforge_version = 20.2.64-beta
+neoforge_version = 20.2.80-beta
 
 # Extra properties
 run_on_quilt = false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -145,7 +145,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
         # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
@@ -153,7 +153,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
       '' | soft) :;; #(
       *)
         # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -200,13 +200,13 @@ fi
 
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+DEFAULT_JVM_OPTS='-Dfile.encoding=UTF-8 "-Xmx64m" "-Xms64m"'
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -34,7 +34,7 @@ set APP_HOME=%DIRNAME%
 for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
+set DEFAULT_JVM_OPTS=-Dfile.encoding=UTF-8 "-Xmx64m" "-Xms64m"
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome

--- a/neoforge/src/main/resources/pack.mcmeta
+++ b/neoforge/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
     "description": "Figura Resources",
-    "pack_format": 15
+    "pack_format": 18
   }
 }


### PR DESCRIPTION
1. Updates Fabric API to [0.91.1](https://github.com/FabricMC/fabric/releases/tag/0.91.1%2B1.20.2),
2. Updates Fabric Loader to [0.14.25](https://github.com/FabricMC/fabric-loader/releases/tag/0.14.25), *(This one matters a bit more due to it containing a vulnerability fix)*
3. Updates Iris to [1.6.10](https://github.com/IrisShaders/Iris/releases/tag/1.6.10%2B1.20.2),
4. Updates ImmediatelyFast to [1.2.7](https://github.com/RaphiMC/ImmediatelyFast/releases/tag/v1.2.7),
5. Updates Forge to [48.1.0](https://maven.minecraftforge.net/net/minecraftforge/forge/1.20.2-48.1.0/forge-1.20.2-48.1.0-changelog.txt),
6. Updates NeoForge to [20.2.86](https://maven.neoforged.net/releases/net/neoforged/neoforge/20.2.86/neoforge-20.2.86-changelog.txt),
7. Updates Gradle to [8.4](https://docs.gradle.org/8.4/release-notes.html) and upstreams the gradlew related scripts with it,
8. Updates Quilt Loader + API to latest versions possible although a notice has been added to indicate that there is no 1.20.2 version for it yet,
9. Updates the `pack.mcmeta` files to match 1.20.2's pack versioning,
10. Updates the workflow script to remove the unused `mergeJars` task and now uploads the NeoForge artifacts.