### PR TITLE
Fix incorrect uv calculations due to BlockBench 4.9

### DIFF
--- a/common/src/main/java/org/figuramc/figura/exporters/BlockBenchModel.java
+++ b/common/src/main/java/org/figuramc/figura/exporters/BlockBenchModel.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 
 public class BlockBenchModel {
 
-    private static final String VERSION = "4.5";
+    private static final String VERSION = "4.9";
 
     private final JsonObject root = new JsonObject();
     private final ArrayList<Cube> elements = new ArrayList<>();
@@ -36,13 +36,17 @@ public class BlockBenchModel {
     }
 
     // returns the image id
-    public int addImage(String name, String source) {
+    public int addImage(String name, String source, int width, int height) {
         int id = textures.size();
 
         JsonObject texture = new JsonObject();
         texture.addProperty("name", name);
         texture.addProperty("id", String.valueOf(id));
         texture.addProperty("source", "data:image/png;base64," + source);
+        texture.addProperty("width", width);
+        texture.addProperty("height", height);
+        texture.addProperty("uv_width", width);
+        texture.addProperty("uv_height", height);
         textures.add(texture);
 
         return id;

--- a/common/src/main/java/org/figuramc/figura/parsers/BlockbenchModel.java
+++ b/common/src/main/java/org/figuramc/figura/parsers/BlockbenchModel.java
@@ -30,6 +30,8 @@ public class BlockbenchModel {
         String name;
         String relative_path;
         String source;
+        Float width, height;
+        Float uv_width, uv_height;
     }
 
     // -- elements -- // 

--- a/common/src/main/java/org/figuramc/figura/parsers/BlockbenchModelParser.java
+++ b/common/src/main/java/org/figuramc/figura/parsers/BlockbenchModelParser.java
@@ -197,8 +197,14 @@ public class BlockbenchModelParser {
                 int id = textureIndex.indexOf(name) + textureOffset;
 
                 //fix texture size for more speed
-                int[] imageSize = getTextureSize(source);
-                float[] fixedSize = new float[]{(float) imageSize[0] / resolution.width, (float) imageSize[1] / resolution.height};
+                float[] fixedSize;
+                if (texture.width != null) {
+                    fixedSize = new float[]{(float) texture.width / texture.uv_width, (float) texture.height / texture.uv_height};
+                }
+                else {
+                    int[] imageSize = getTextureSize(source);
+                    fixedSize = new float[]{(float) imageSize[0] / resolution.width, (float) imageSize[1] / resolution.height};
+                }
 
                 //add the texture on the map
                 textureMap.put(name, new TextureData(id, fixedSize));

--- a/common/src/main/java/org/figuramc/figura/wizards/AvatarWizard.java
+++ b/common/src/main/java/org/figuramc/figura/wizards/AvatarWizard.java
@@ -235,8 +235,8 @@ public class AvatarWizard {
         BlockBenchModel model = new BlockBenchModel("free");
 
         //textures
-        int playerTex = hasPlayer ? model.addImage("Skin", slim ? playerTextureSlim : playerTexture) : -1;
-        int capeTex = hasCapeOrElytra ? model.addImage("Cape", capeTexture) : -1;
+        int playerTex = hasPlayer ? model.addImage("Skin", slim ? playerTextureSlim : playerTexture, 64, 64) : -1;
+        int capeTex = hasCapeOrElytra ? model.addImage("Cape", capeTexture, 64, 32) : -1;
 
         //resolution
         if (hasPlayer)


### PR DESCRIPTION
Blockbench 4.9 adds per-texture uv sizes which completely breaks how Figura calculates uvs.
This fixes that by grabbing the texture width, height, uv_width, and uv_height from the bbmodel and using those to calculate the uvs per texture, instead of the ProjectUV

If the texture width doesnt exist, it is assumed that the bbmodel is from 4.8 or below and will use the old method for backwards compatibility