### PR TITLE
*raycasting*

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/FiguraAPIManager.java
+++ b/common/src/main/java/org/figuramc/figura/lua/FiguraAPIManager.java
@@ -135,6 +135,8 @@ public class FiguraAPIManager {
         add(ConfigAPI.class);
 
         add(TextureAtlasAPI.class);
+
+        add(RaycastAPI.class);
     }};
 
     public static final Map<String, Function<FiguraLuaRuntime, Object>> API_GETTERS = new LinkedHashMap<>() {{
@@ -156,6 +158,7 @@ public class FiguraAPIManager {
         put("pings", r -> r.ping = new PingAPI(r.owner));
         put("textures", r -> r.texture = new TextureAPI(r.owner));
         put("config", r -> new ConfigAPI(r.owner));
+        put("raycast", r -> new RaycastAPI(r.owner));
     }};
 
     private static final Set<FiguraAPI> ENTRYPOINTS = new HashSet<>();

--- a/common/src/main/java/org/figuramc/figura/lua/api/RaycastAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/RaycastAPI.java
@@ -1,0 +1,138 @@
+package org.figuramc.figura.lua.api;
+
+import java.util.function.Predicate;
+
+import org.figuramc.figura.avatar.Avatar;
+import org.figuramc.figura.lua.LuaWhitelist;
+import org.figuramc.figura.lua.api.entity.EntityAPI;
+import org.figuramc.figura.lua.api.world.WorldAPI;
+import org.figuramc.figura.lua.docs.LuaMethodDoc;
+import org.figuramc.figura.lua.docs.LuaMethodOverload;
+import org.figuramc.figura.lua.docs.LuaTypeDoc;
+import org.figuramc.figura.math.vector.FiguraVec3;
+import org.figuramc.figura.utils.LuaUtils;
+import org.luaj.vm2.LuaError;
+import org.luaj.vm2.LuaFunction;
+import org.luaj.vm2.LuaValue;
+
+import com.mojang.datafixers.util.Pair;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.Marker;
+import net.minecraft.world.entity.projectile.ProjectileUtil;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.EntityHitResult;
+
+@LuaWhitelist
+@LuaTypeDoc(
+        name = "RaycastAPI",
+        value = "raycast"
+)
+public class RaycastAPI {
+    
+    private final Avatar owner;
+
+    public RaycastAPI(Avatar owner) {
+        this.owner = owner;
+    }
+
+    
+    @LuaWhitelist
+    @LuaMethodDoc(
+            overloads = {
+                    @LuaMethodOverload(
+                            argumentTypes = {String.class, String.class, FiguraVec3.class, FiguraVec3.class},
+                            argumentNames = {"blockCastType", "fluidCastType", "start", "end"}
+                    ),
+                    @LuaMethodOverload(
+                            argumentTypes = {String.class, String.class, Double.class, Double.class, Double.class, FiguraVec3.class},
+                            argumentNames = {"blockCastType", "fluidCastType", "startX", "startY", "startZ", "end"}
+                    ),
+                    @LuaMethodOverload(
+                            argumentTypes = {String.class, String.class, FiguraVec3.class, Double.class, Double.class, Double.class},
+                            argumentNames = {"blockCastType", "fluidCastType", "start", "endX", "endY", "endZ"}
+                    ),
+                    @LuaMethodOverload(
+                            argumentTypes = {String.class, String.class, Double.class, Double.class, Double.class, Double.class, Double.class, Double.class},
+                            argumentNames = {"blockCastType", "fluidCastType", "startX", "startY", "startZ", "endX", "endY", "endZ"}
+                    )
+                }
+            ,
+            value = "raycast.block"
+    )
+    public Object[] block(String blockCastType, String fluidCastType, Object x, Object y, Double z, Object w, Double t, Double h) {
+        FiguraVec3 start, end;
+
+        Pair<FiguraVec3, FiguraVec3> pair = LuaUtils.parse2Vec3("block", x, y, z, w, t, h,1);
+        start = pair.getFirst();
+        end = pair.getSecond();
+
+        ClipContext.Block blockContext;
+        try{
+            blockContext = blockCastType != null ? ClipContext.Block.valueOf(blockCastType.toUpperCase()) : ClipContext.Block.COLLIDER;
+        }
+        catch(IllegalArgumentException e){
+            throw new LuaError("Invalid blockRaycastType provided");
+        }
+
+        ClipContext.Fluid fluidContext;
+        try{
+            fluidContext = fluidCastType != null ? ClipContext.Fluid.valueOf(fluidCastType.toUpperCase()) : ClipContext.Fluid.NONE;
+        }
+        catch(IllegalArgumentException e){
+            throw new LuaError("Invalid fluidRaycastType provided");
+        }
+
+        BlockHitResult result = WorldAPI.getCurrentWorld().clip(new ClipContext(start.asVec3(), end.asVec3(), blockContext, fluidContext, new Marker(EntityType.MARKER, WorldAPI.getCurrentWorld())));
+        return LuaUtils.parseBlockHitResult(result);
+    }
+
+    @LuaWhitelist
+    @LuaMethodDoc(
+            overloads = {
+                    @LuaMethodOverload(
+                            argumentTypes = {LuaFunction.class, FiguraVec3.class, FiguraVec3.class},
+                            argumentNames = {"predicate", "start", "end"}
+                    ),
+                    @LuaMethodOverload(
+                            argumentTypes = {LuaFunction.class, Double.class, Double.class, Double.class, FiguraVec3.class},
+                            argumentNames = {"predicate", "startX", "startY", "startZ", "end"}
+                    ),
+                    @LuaMethodOverload(
+                            argumentTypes = {LuaFunction.class, FiguraVec3.class, Double.class, Double.class, Double.class},
+                            argumentNames = {"predicate", "start", "endX", "endY", "endZ"}
+                    ),
+                    @LuaMethodOverload(
+                            argumentTypes = {LuaFunction.class, Double.class, Double.class, Double.class, Double.class, Double.class, Double.class},
+                            argumentNames = {"predicate", "startX", "startY", "startZ", "endX", "endY", "endZ"}
+                    )
+            }
+            ,
+            value = "raycast.entity"
+    )
+    public Object[] entity(LuaFunction predicate, Object x, Object y, Double z, Object w, Double t, Double h) {
+        FiguraVec3 start, end;
+
+        Pair<FiguraVec3, FiguraVec3> pair = LuaUtils.parse2Vec3("entity", x, y, z, w, t, h, 1);
+        start = pair.getFirst();
+        end = pair.getSecond();
+
+        Predicate<Entity> entityPredicate = (entity) -> {
+            if (predicate == null) return true;
+            LuaValue result = predicate.invoke(this.owner.luaRuntime.typeManager.javaToLua(EntityAPI.wrap(entity))).arg1();
+            if ((result.isboolean() && result.checkboolean() == false) || result.isnil())
+                return false;
+            return true;
+        };
+
+        EntityHitResult result = ProjectileUtil.getEntityHitResult(new Marker(EntityType.MARKER, WorldAPI.getCurrentWorld()), start.asVec3(), end.asVec3(), new AABB(start.asVec3(), end.asVec3()), entityPredicate, Double.MAX_VALUE);
+
+        if (result != null)
+            return new Object[]{EntityAPI.wrap(result.getEntity()), FiguraVec3.fromVec3(result.getLocation())};
+
+        return null;
+    }
+}

--- a/common/src/main/java/org/figuramc/figura/lua/api/world/WorldAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/world/WorldAPI.java
@@ -7,20 +7,12 @@ import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.arguments.blocks.BlockStateArgument;
 import net.minecraft.commands.arguments.item.ItemArgument;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.Marker;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.entity.projectile.ProjectileUtil;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.AABB;
-import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.phys.EntityHitResult;
-import net.minecraft.world.phys.HitResult;
 import org.figuramc.figura.avatar.Avatar;
 import org.figuramc.figura.avatar.AvatarManager;
 import org.figuramc.figura.lua.LuaNotNil;
@@ -390,91 +382,6 @@ public class WorldAPI {
         } catch (Exception ignored) {
             throw new LuaError("Invalid UUID");
         }
-    }
-
-    @LuaWhitelist
-    @LuaMethodDoc(
-            overloads = {
-                    @LuaMethodOverload(
-                    argumentTypes = {Boolean.class, FiguraVec3.class, FiguraVec3.class},
-                    argumentNames = {"fluid", "start", "end"}
-                    ),
-                    @LuaMethodOverload(
-                            argumentTypes = {Boolean.class, Double.class, Double.class, Double.class, FiguraVec3.class},
-                            argumentNames = {"fluid", "startX", "startY", "startZ", "end"}
-                    ),
-                    @LuaMethodOverload(
-                            argumentTypes = {Boolean.class, FiguraVec3.class, Double.class, Double.class, Double.class},
-                            argumentNames = {"fluid", "start", "endX", "endY", "endZ"}
-                    ),
-                    @LuaMethodOverload(
-                            argumentTypes = {Boolean.class, Double.class, Double.class, Double.class, Double.class, Double.class, Double.class},
-                            argumentNames = {"fluid", "startX", "startY", "startZ", "endX", "endY", "endZ"}
-                    )
-                }
-            ,
-            value = "world.raycast_block"
-    )
-    public HashMap<String, Object> raycastBlock(boolean fluid, Object x, Object y, Double z, Object w, Double t, Double h) {
-        FiguraVec3 start, end;
-
-        Pair<FiguraVec3, FiguraVec3> pair = LuaUtils.parse2Vec3("raycastBlock", x, y, z, w, t, h,1);
-        start = pair.getFirst();
-        end = pair.getSecond();
-
-        BlockHitResult result = getCurrentWorld().clip(new ClipContext(start.asVec3(), end.asVec3(), ClipContext.Block.OUTLINE, fluid ? ClipContext.Fluid.NONE : ClipContext.Fluid.ANY, new Marker(EntityType.MARKER, getCurrentWorld())));
-        if (result == null || result.getType() == HitResult.Type.MISS)
-            return null;
-
-        HashMap<String, Object> map = new HashMap<>();
-        BlockPos pos = result.getBlockPos();
-        map.put("block", getBlockState(pos.getX(), (double) pos.getY(), (double) pos.getZ()));
-        map.put("direction", result.getDirection().getName());
-        map.put("pos", FiguraVec3.fromVec3(result.getLocation()));
-
-        return map;
-    }
-
-    @LuaWhitelist
-    @LuaMethodDoc(
-            overloads = {
-                    @LuaMethodOverload(
-                            argumentTypes = {FiguraVec3.class, FiguraVec3.class},
-                            argumentNames = {"start", "end"}
-                    ),
-                    @LuaMethodOverload(
-                            argumentTypes = {Double.class, Double.class, Double.class, FiguraVec3.class},
-                            argumentNames = {"startX", "startY", "startZ", "end"}
-                    ),
-                    @LuaMethodOverload(
-                            argumentTypes = {FiguraVec3.class, Double.class, Double.class, Double.class},
-                            argumentNames = {"start", "endX", "endY", "endZ"}
-                    ),
-                    @LuaMethodOverload(
-                            argumentTypes = {Double.class, Double.class, Double.class, Double.class, Double.class, Double.class},
-                            argumentNames = {"startX", "startY", "startZ", "endX", "endY", "endZ"}
-                    )
-            }
-            ,
-            value = "world.raycast_entity"
-    )
-    public HashMap<String, Object> raycastEntity(Object x, Object y, Double z, Object w, Double t, Double h) {
-        FiguraVec3 start, end;
-
-        Pair<FiguraVec3, FiguraVec3> pair = LuaUtils.parse2Vec3("raycastEntity", x, y, z, w, t, h, 1);
-        start = pair.getFirst();
-        end = pair.getSecond();
-
-        EntityHitResult result = ProjectileUtil.getEntityHitResult(new Marker(EntityType.MARKER, getCurrentWorld()), start.asVec3(), end.asVec3(), new AABB(start.asVec3(), end.asVec3()), entity -> true, Double.MAX_VALUE);
-
-        if (result == null)
-            return null;
-
-        HashMap<String, Object> map = new HashMap<>();
-        map.put("entity", EntityAPI.wrap(result.getEntity()));
-        map.put("pos", FiguraVec3.fromVec3(result.getLocation()));
-
-        return map;
     }
 
     @LuaWhitelist

--- a/common/src/main/java/org/figuramc/figura/lua/docs/FiguraDocsManager.java
+++ b/common/src/main/java/org/figuramc/figura/lua/docs/FiguraDocsManager.java
@@ -224,6 +224,10 @@ public class FiguraDocsManager {
         put("config", List.of(
                 ConfigAPI.class
         ));
+
+        put("raycast", List.of(
+                RaycastAPI.class
+        ));
     }};
     private static final Map<String, List<FiguraDoc>> GENERATED_CHILDREN = new HashMap<>();
 

--- a/common/src/main/java/org/figuramc/figura/lua/docs/FiguraGlobalsDocs.java
+++ b/common/src/main/java/org/figuramc/figura/lua/docs/FiguraGlobalsDocs.java
@@ -77,6 +77,8 @@ public abstract class FiguraGlobalsDocs {
     public TextureAPI textures;
     @LuaFieldDoc("globals.config")
     public ConfigAPI config;
+    @LuaFieldDoc("globals.raycast")
+    public RaycastAPI raycast;
 
     @LuaFieldDoc("globals.type")
     public LuaFunction type;

--- a/common/src/main/java/org/figuramc/figura/lua/docs/FiguraListDocs.java
+++ b/common/src/main/java/org/figuramc/figura/lua/docs/FiguraListDocs.java
@@ -13,6 +13,8 @@ import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.player.PlayerModelPart;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.UseAnim;
+import net.minecraft.world.level.ClipContext;
+
 import org.figuramc.figura.FiguraMod;
 import org.figuramc.figura.animation.Animation;
 import org.figuramc.figura.mixin.input.KeyMappingAccessor;
@@ -89,6 +91,14 @@ public class FiguraListDocs {
         for (EntityRenderMode value : EntityRenderMode.values())
             add(value.name());
     }};
+    private static final LinkedHashSet<String> BLOCK_RAYCAST_TYPE = new LinkedHashSet<>() {{
+        for (ClipContext.Block value : ClipContext.Block.values())
+            add(value.name());
+    }};
+    private static final LinkedHashSet<String> FLUID_RAYCAST_TYPE = new LinkedHashSet<>() {{
+        for (ClipContext.Fluid value : ClipContext.Fluid.values())
+            add(value.name());
+    }};
 
     private enum ListDoc {
         KEYBINDS(() -> FiguraListDocs.KEYBINDS, "Keybinds", "keybinds", 2),
@@ -104,7 +114,9 @@ public class FiguraListDocs {
         COLORS(() -> FiguraListDocs.COLORS, "Colors", "colors", 1),
         PLAYER_MODEL_PARTS(() -> FiguraListDocs.PLAYER_MODEL_PARTS, "PlayerModelParts", "player_model_parts", 1),
         USE_ACTIONS(() -> FiguraListDocs.USE_ACTIONS, "UseActions", "use_actions", 1),
-        RENDER_MODES(() -> FiguraListDocs.RENDER_MODES, "RenderModes", "render_modes", 1);
+        RENDER_MODES(() -> FiguraListDocs.RENDER_MODES, "RenderModes", "render_modes", 1),
+        BLOCK_RAYCAST_TYPE(() -> FiguraListDocs.BLOCK_RAYCAST_TYPE, "BlockRaycastTypes", "block_raycast_types", 1),
+        FLUID_RAYCAST_TYPE(() -> FiguraListDocs.FLUID_RAYCAST_TYPE, "FluidRaycastTypes", "fluid_raycast_types", 1);
 
         private final Supplier<Object> supplier;
         private final String name, id;

--- a/common/src/main/resources/assets/figura/lang/en_us.json
+++ b/common/src/main/resources/assets/figura/lang/en_us.json
@@ -585,6 +585,8 @@
     "figura.docs.enum.player_model_parts": "List of valid PlayerModelParts\nUsed within the PlayerAPI",
     "figura.docs.enum.use_actions": "List of valid UseActions\nUsed within the ItemStackAPI",
     "figura.docs.enum.render_modes": "List of valid RenderModes\nUsed within the RENDER event",
+    "figura.docs.enum.block_raycast_types": "List of valid BlockRaycastTypes\nUsed to determine how raycast.block handles blocks",
+    "figura.docs.enum.fluid_raycast_types": "List of valid FluidRaycastTypes\nUsed to determine how raycast.block handles fluids",
     "figura.docs.globals": "Documentation for the various things Figura adds to the global lua state",
     "figura.docs.globals.vec": "An alias for \"vectors.vec\"",
     "figura.docs.globals.require": "The require() function takes the name of one of your scripts, without the .lua extension\nIf this script has not been already run before, it will run that script and return the value that script returns\nIf it has been run before, then it will not run the file again, but it will return the same thing as the first time\nIf a required script has no returns, then require() will return true\nIf the name you give isn't any of your scripts, it will error",
@@ -617,6 +619,7 @@
     "figura.docs.globals.pings": "The global instance of PingAPI",
     "figura.docs.globals.textures": "The global instance of the TextureAPI",
     "figura.docs.globals.config": "The global instance of the ConfigAPI",
+    "figura.docs.globals.raycast": "The global instance of RaycastAPI",
     "figura.docs.math": "Contains functions which Figura adds to the default Lua \"math\" library table",
     "figura.docs.math.player_scale": "The constant of the player scaling related to the world",
     "figura.docs.math.world_scale": "The constant of the world scaling related with the player",
@@ -1271,6 +1274,9 @@
     "figura.docs.particle.set_physics": "Sets if this particle has physics",
     "figura.docs.pings": "A global API dedicated to register and call pings",
     "figura.docs.ping_function": "A custom function wrapped with networking data",
+    "figura.docs.raycast": "A global API which provides functions for raycasting",
+    "figura.docs.raycast.block": "Raycasts a Block in the world.\nIf successful, returns the BlockState hit, the exact world position hit as a Vector3, and the side of the block that was hit.\nWhen unsuccessful, returns nil.\nblockCastType and fluidCastType determine how the raycast handles block shapes and fluids.\nWill default to \"COLLIDER\" and \"NONE\" when nil",
+    "figura.docs.raycast.entity": "Raycasts an Entity in the world\nIf successful, returns the EntityAPI hit and the exact world position hit as a Vector3.\nWhen unsuccessful, returns nil.\npredicate is a function that prevents specific entities from being raycasted.\nTakes in a single EntityAPI object. Return true for valid entities, false for invalid.\nMarks all entities as valid when nil",
     "figura.docs.render_task": "Represents a rendering task for Figura to complete each frame\nAn abstract superclass of ItemTask, BlockTask, and TextTask",
     "figura.docs.render_task.remove": "Removes this render task from the parent model part",
     "figura.docs.render_task.get_name": "Get this task's name",
@@ -1590,7 +1596,5 @@
     "figura.docs.world.new_item": "Parses and create a new ItemStack from the given string\nA count and damage can be given, to be applied on this itemstack",
     "figura.docs.world.exists": "Checks whether or not a world currently exists\nThis will almost always be true, but might be false on some occasions such as while travelling between dimensions",
     "figura.docs.world.get_build_height": "Returns the minimum and maximum build height of the world, as varargs",
-    "figura.docs.world.get_spawn_point": "Returns a vector with the coordinates of the world spawn",
-    "figura.docs.world.raycast_entity": "Raycasts an Entity in the world, returns a map containing the entity and it's position.",
-    "figura.docs.world.raycast_block": "Raycasts a Block in the world, returns a map containing the block and it's position."
+    "figura.docs.world.get_spawn_point": "Returns a vector with the coordinates of the world spawn"
 }


### PR DESCRIPTION
Moves raycasting functions to it's own RaycastAPI so that we can do predicate.
`raycastBlock` has been renamed to `block` and now takes in a BlockRaycastType and FluidRaycastType
`raycastEntity` has been renamed to `entity` and now takes in a predicate function with a single Entity argument and returns a boolean. Controls which entities are valid returns when raycasting

adds the BlockRaycastType and FluidRaycastType enums to the docs.