### PR TITLE
Optimize Avatar NBT - Scripts

### DIFF
--- a/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
+++ b/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
@@ -23,6 +23,8 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.nbt.Tag;
+import net.minecraft.nbt.TagType;
+import net.minecraft.nbt.TagTypes;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -75,6 +77,8 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Consumer;
+
+import javax.swing.RowFilter.Entry;
 
 // the avatar class
 // contains all things related to the avatar
@@ -927,10 +931,8 @@ public class Avatar {
         if (!nbt.contains("scripts"))
             return;
 
-        Map<String, String> scripts = new HashMap<>();
         CompoundTag scriptsNbt = nbt.getCompound("scripts");
-        for (String s : scriptsNbt.getAllKeys())
-            scripts.put(s, new String(scriptsNbt.getByteArray(s), StandardCharsets.UTF_8));
+        Map<String, String> scripts = loadScript(scriptsNbt, "");
 
         CompoundTag metadata = nbt.getCompound("metadata");
 
@@ -951,6 +953,17 @@ public class Avatar {
             if (runtime.init(autoScripts))
                 init.use(runtime.getInstructions());
         });
+    }
+    
+    public Map<String, String> loadScript(CompoundTag tag, String path) {
+        Map<String, String> result = new HashMap<>();
+        for (String key : tag.getAllKeys()){
+            switch(tag.get(key).getId()){
+                case Tag.TAG_COMPOUND -> result.putAll(loadScript(tag.getCompound(key), path + key + "."));
+                case Tag.TAG_BYTE_ARRAY -> result.put(path + key, new String(tag.getByteArray(key), StandardCharsets.UTF_8));
+            }
+        }
+        return result;
     }
 
     private void loadAnimations() {

--- a/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
+++ b/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
@@ -23,8 +23,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.nbt.Tag;
-import net.minecraft.nbt.TagType;
-import net.minecraft.nbt.TagTypes;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -77,8 +75,6 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Consumer;
-
-import javax.swing.RowFilter.Entry;
 
 // the avatar class
 // contains all things related to the avatar

--- a/common/src/main/java/org/figuramc/figura/avatar/local/LocalAvatarLoader.java
+++ b/common/src/main/java/org/figuramc/figura/avatar/local/LocalAvatarLoader.java
@@ -179,19 +179,6 @@ public class LocalAvatarLoader {
                 }
             }
         return nbt;
-        // List<Path> scripts = IOUtils.getFilesByExtension(path, ".lua");
-        // if (scripts.size() > 0) {
-        //     CompoundTag scriptsNbt = new CompoundTag();
-        //     String pathRegex = path.toString().isEmpty() ? "\\Q\\E" : Pattern.quote(path + path.getFileSystem().getSeparator());
-        //     for (Path script : scripts) {
-        //         String name = script.toString()
-        //                 .replaceFirst(pathRegex, "")
-        //                 .replaceAll("[/\\\\]", ".");
-        //         name = name.substring(0, name.length() - 4);
-        //         scriptsNbt.put(name, LuaScriptParser.parseScript(name, IOUtils.readFile(script)));
-        //     }
-        //     nbt.put("scripts", scriptsNbt);
-        // }
     }
 
     private static void loadSounds(Path path, CompoundTag nbt) throws IOException {

--- a/common/src/main/java/org/figuramc/figura/avatar/local/LocalAvatarLoader.java
+++ b/common/src/main/java/org/figuramc/figura/avatar/local/LocalAvatarLoader.java
@@ -118,7 +118,9 @@ public class LocalAvatarLoader {
 
                 // scripts
                 loadState = LoadState.SCRIPTS;
-                loadScripts(finalPath, nbt);
+                CompoundTag scripts = loadScripts(finalPath);
+                if (!scripts.getAllKeys().isEmpty())
+                    nbt.put("scripts", scripts);
 
                 // custom sounds
                 loadState = LoadState.SOUNDS;
@@ -158,20 +160,38 @@ public class LocalAvatarLoader {
         });
     }
 
-    private static void loadScripts(Path path, CompoundTag nbt) throws IOException {
-        List<Path> scripts = IOUtils.getFilesByExtension(path, ".lua");
-        if (scripts.size() > 0) {
-            CompoundTag scriptsNbt = new CompoundTag();
-            String pathRegex = path.toString().isEmpty() ? "\\Q\\E" : Pattern.quote(path + path.getFileSystem().getSeparator());
-            for (Path script : scripts) {
-                String name = script.toString()
-                        .replaceFirst(pathRegex, "")
-                        .replaceAll("[/\\\\]", ".");
-                name = name.substring(0, name.length() - 4);
-                scriptsNbt.put(name, LuaScriptParser.parseScript(name, IOUtils.readFile(script)));
+    private static CompoundTag loadScripts(Path path) throws IOException {
+        CompoundTag nbt = new CompoundTag();
+        List<Path> subFiles = IOUtils.listPaths(path);
+        if (subFiles != null)
+            for (Path file : subFiles) {
+                if (IOUtils.isHidden(file))
+                    continue;
+                String name = IOUtils.getFileNameOrEmpty(file);
+                if (Files.isDirectory(file)) {
+                    CompoundTag folderNbt = loadScripts(file);
+                    if (folderNbt.getAllKeys().isEmpty())
+                        continue;
+                    nbt.put(name, folderNbt);
+                } else if (file.toString().toLowerCase().endsWith(".lua")) {
+                    name = name.substring(0, name.length() - 4);
+                    nbt.put(name, LuaScriptParser.parseScript(name, IOUtils.readFile(file)));
+                }
             }
-            nbt.put("scripts", scriptsNbt);
-        }
+        return nbt;
+        // List<Path> scripts = IOUtils.getFilesByExtension(path, ".lua");
+        // if (scripts.size() > 0) {
+        //     CompoundTag scriptsNbt = new CompoundTag();
+        //     String pathRegex = path.toString().isEmpty() ? "\\Q\\E" : Pattern.quote(path + path.getFileSystem().getSeparator());
+        //     for (Path script : scripts) {
+        //         String name = script.toString()
+        //                 .replaceFirst(pathRegex, "")
+        //                 .replaceAll("[/\\\\]", ".");
+        //         name = name.substring(0, name.length() - 4);
+        //         scriptsNbt.put(name, LuaScriptParser.parseScript(name, IOUtils.readFile(script)));
+        //     }
+        //     nbt.put("scripts", scriptsNbt);
+        // }
     }
 
     private static void loadSounds(Path path, CompoundTag nbt) throws IOException {


### PR DESCRIPTION
Optimizes the Avatar nbt by saving scripts as a Compound Tag mimiking the file structure instead of repeating the path per script.
Additionally, it updates the `/figura debug` command to reflect these changes

This is the nbt pre-optimization
![image](https://github.com/FiguraMC/Figura/assets/94943674/9ee3e4e1-bb49-4e06-97ed-bf45fde070db)

This is the nbt post-optimization
![image](https://github.com/FiguraMC/Figura/assets/94943674/5037ba09-5b42-4ab4-b61d-03db7f199553)

While this doesn't save much filesize, it doesnt cost any filesize meaning this is a free optimization.

This will break avatars that rely on the old nbt format via `avatar:getNBT()`, but in my opinion, ".moon files are an internal format liable to change" :P

`require` functionality is untouched

**edit** I switched the images lmao