### PR TITLE
Reverts the avatar nbt change and listFiles now returns `.` as the se…

### DIFF
--- a/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
+++ b/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
@@ -61,7 +61,6 @@ import org.figuramc.figura.permissions.PermissionPack;
 import org.figuramc.figura.permissions.Permissions;
 import org.figuramc.figura.utils.ColorUtils;
 import org.figuramc.figura.utils.EntityUtils;
-import org.figuramc.figura.utils.PathUtils;
 import org.figuramc.figura.utils.RefilledNumber;
 import org.figuramc.figura.utils.Version;
 import org.figuramc.figura.utils.ui.UIHelper;
@@ -992,8 +991,10 @@ public class Avatar {
         if (!nbt.contains("scripts"))
             return;
 
+        Map<String, String> scripts = new HashMap<>();
         CompoundTag scriptsNbt = nbt.getCompound("scripts");
-        Map<String, String> scripts = loadScript(scriptsNbt, "");
+        for (String s : scriptsNbt.getAllKeys())
+            scripts.put(s, new String(scriptsNbt.getByteArray(s), StandardCharsets.UTF_8));
 
         CompoundTag metadata = nbt.getCompound("metadata");
 
@@ -1014,17 +1015,6 @@ public class Avatar {
             if (runtime.init(autoScripts))
                 init.use(runtime.getInstructions());
         });
-    }
-    
-    public Map<String, String> loadScript(CompoundTag tag, String path) {
-        Map<String, String> result = new HashMap<>();
-        for (String key : tag.getAllKeys()){
-            switch(tag.get(key).getId()){
-                case Tag.TAG_COMPOUND -> result.putAll(loadScript(tag.getCompound(key), path + key + "/"));
-                case Tag.TAG_BYTE_ARRAY -> result.put(PathUtils.computeSafeString(path + key), new String(tag.getByteArray(key), StandardCharsets.UTF_8));
-            }
-        }
-        return result;
     }
 
     private void loadAnimations() {

--- a/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
+++ b/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
@@ -61,6 +61,7 @@ import org.figuramc.figura.permissions.PermissionPack;
 import org.figuramc.figura.permissions.Permissions;
 import org.figuramc.figura.utils.ColorUtils;
 import org.figuramc.figura.utils.EntityUtils;
+import org.figuramc.figura.utils.PathUtils;
 import org.figuramc.figura.utils.RefilledNumber;
 import org.figuramc.figura.utils.Version;
 import org.figuramc.figura.utils.ui.UIHelper;
@@ -994,7 +995,7 @@ public class Avatar {
         Map<String, String> scripts = new HashMap<>();
         CompoundTag scriptsNbt = nbt.getCompound("scripts");
         for (String s : scriptsNbt.getAllKeys())
-            scripts.put(s, new String(scriptsNbt.getByteArray(s), StandardCharsets.UTF_8));
+            scripts.put(PathUtils.computeSafeString(s), new String(scriptsNbt.getByteArray(s), StandardCharsets.UTF_8));
 
         CompoundTag metadata = nbt.getCompound("metadata");
 

--- a/common/src/main/java/org/figuramc/figura/avatar/local/LocalAvatarLoader.java
+++ b/common/src/main/java/org/figuramc/figura/avatar/local/LocalAvatarLoader.java
@@ -14,7 +14,6 @@ import org.figuramc.figura.parsers.LuaScriptParser;
 import org.figuramc.figura.utils.FiguraResourceListener;
 import org.figuramc.figura.utils.FiguraText;
 import org.figuramc.figura.utils.IOUtils;
-import org.figuramc.figura.utils.PathUtils;
 
 import java.io.*;
 import java.nio.file.*;
@@ -223,10 +222,10 @@ public class LocalAvatarLoader {
             CompoundTag scriptsNbt = new CompoundTag();
             String pathRegex = path.toString().isEmpty() ? "\\Q\\E" : Pattern.quote(path + path.getFileSystem().getSeparator());
             for (Path script : scripts) {
-                String name = PathUtils.computeSafeString(script.toString()
-                    .replaceFirst(pathRegex, "")
-                    .replaceAll("\\.lua$", "")
-                );
+                String name = script.toString()
+                        .replaceFirst(pathRegex, "")
+                        .replaceAll("[/\\\\]", ".");
+                name = name.substring(0, name.length() - 4);
                 scriptsNbt.put(name, LuaScriptParser.parseScript(name, IOUtils.readFile(script)));
             }
             nbt.put("scripts", scriptsNbt);

--- a/common/src/main/java/org/figuramc/figura/commands/DebugCommand.java
+++ b/common/src/main/java/org/figuramc/figura/commands/DebugCommand.java
@@ -298,7 +298,7 @@ class DebugCommand {
 
         // scripts
         CompoundTag scriptsNbt = nbt.getCompound("scripts");
-        JsonElement scripts = parseTagRecursive(scriptsNbt);
+        JsonElement scripts = parseCompoundSize(scriptsNbt);
         sizes.add("scripts", scripts);
         sizes.addProperty("scripts_total", parseSize(getBytesFromNbt(scriptsNbt)));
 

--- a/common/src/main/java/org/figuramc/figura/lua/FiguraLuaRuntime.java
+++ b/common/src/main/java/org/figuramc/figura/lua/FiguraLuaRuntime.java
@@ -272,7 +272,7 @@ public class FiguraLuaRuntime {
                 // If we do not allow subfolders, only allow paths that directly point to a file
                 if (!subFolders && result.getNameCount()!=1)
                     continue;
-                table.set(i++, LuaValue.valueOf(s));
+                table.set(i++, LuaValue.valueOf(s.replace('/', '.')));
             }
 
             return table;


### PR DESCRIPTION
Reverts changing the avatar nbt structure. The "free optimization" turned out to not be free.

additionally, reverts the file separator that listFiles returns due to major complaints.