### PR TITLE
allow disabling root model rotations

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/RendererAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/RendererAPI.java
@@ -61,6 +61,7 @@ public class RendererAPI {
     public FiguraVec3 eyeOffset;
     public FiguraVec4 blockOutlineColor;
     public Boolean upsideDown;
+    public Boolean rootRotation;
 
     public RendererAPI(Avatar owner) {
         this.owner = owner.owner;
@@ -704,6 +705,31 @@ public class RendererAPI {
     @LuaWhitelist
     public RendererAPI blockOutlineColor(Object r, Double g, Double b, Double a) {
         return setBlockOutlineColor(r, g, b, a);
+    }
+
+    @LuaWhitelist
+    @LuaMethodDoc(
+            overloads = @LuaMethodOverload(
+                    argumentTypes = Boolean.class,
+                    argumentNames = "bool"
+            ),
+            aliases = "rootRotationAllowed",
+            value = "renderer.set_root_rotation_allowed"
+    )
+    public RendererAPI setRootRotationAllowed(Boolean bool) {
+        this.rootRotation = bool;
+        return this;
+    }
+
+    @LuaWhitelist
+    public RendererAPI rootRotationAllowed(Boolean bool) {
+        return setRootRotationAllowed(bool);
+    }
+
+    @LuaWhitelist
+    @LuaMethodDoc("renderer.get_root_rotation_allowed")
+    public Boolean getRootRotationAllowed() {
+        return rootRotation != null ? rootRotation : true;
     }
 
     @LuaWhitelist

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/PlayerRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/PlayerRendererMixin.java
@@ -12,6 +12,7 @@ import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.player.PlayerRenderer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.scores.Objective;
 import net.minecraft.world.scores.Score;
 import net.minecraft.world.scores.Scoreboard;
@@ -26,6 +27,7 @@ import org.figuramc.figura.lua.api.nameplate.EntityNameplateCustomization;
 import org.figuramc.figura.lua.api.vanilla_model.VanillaPart;
 import org.figuramc.figura.math.vector.FiguraVec3;
 import org.figuramc.figura.permissions.Permissions;
+import org.figuramc.figura.utils.RenderUtils;
 import org.figuramc.figura.utils.TextUtils;
 import org.joml.Matrix4f;
 import org.spongepowered.asm.mixin.Mixin;
@@ -237,5 +239,13 @@ public abstract class PlayerRendererMixin extends LivingEntityRenderer<AbstractC
             avatar.luaRuntime.vanilla_model.PLAYER.restore(this.getModel());
 
         avatar = null;
+    }
+
+    @Inject(method = "setupRotations", at = @At("HEAD"), cancellable = true)
+    private void setupRotations(AbstractClientPlayer entity, PoseStack poseStack, float f, float f2, float f3, CallbackInfo cir) {
+        Avatar avatar = AvatarManager.getAvatar(entity);
+        if (RenderUtils.vanillaModelAndScript(avatar) && !avatar.luaRuntime.renderer.getRootRotationAllowed()) {
+            cir.cancel();
+        }
     }
 }

--- a/common/src/main/java/org/figuramc/figura/utils/ui/UIHelper.java
+++ b/common/src/main/java/org/figuramc/figura/utils/ui/UIHelper.java
@@ -33,6 +33,7 @@ import org.figuramc.figura.gui.widgets.FiguraWidget;
 import org.figuramc.figura.math.vector.FiguraVec4;
 import org.figuramc.figura.model.rendering.EntityRenderMode;
 import org.figuramc.figura.utils.FiguraIdentifier;
+import org.figuramc.figura.utils.RenderUtils;
 import org.figuramc.figura.utils.TextUtils;
 import org.joml.Matrix4f;
 import org.joml.Quaternionf;
@@ -196,6 +197,11 @@ public final class UIHelper {
         pose.scale(scale, scale, scale);
         pose.last().pose().scale(1f, 1f, -1f); // Scale ONLY THE POSITIONS! Inverted normals don't work for whatever reason
 
+        Avatar avatar = AvatarManager.getAvatar(entity);
+        if (RenderUtils.vanillaModelAndScript(avatar) && !avatar.luaRuntime.renderer.getRootRotationAllowed()) {
+            yRot = yaw;
+        }
+
         // apply rotations
         Quaternionf quaternion = Axis.ZP.rotationDegrees(180f);
         Quaternionf quaternion2 = Axis.YP.rotationDegrees(yRot);
@@ -219,7 +225,6 @@ public final class UIHelper {
         fireRot = -yRot;
         dollScale = scale;
 
-        Avatar avatar = AvatarManager.getAvatar(entity);
         if (avatar != null) avatar.renderMode = renderMode;
 
         double finalXPos = xPos;

--- a/common/src/main/resources/assets/figura/lang/en_us.json
+++ b/common/src/main/resources/assets/figura/lang/en_us.json
@@ -1455,6 +1455,8 @@
     "figura.docs.renderer.get_eye_offset": "Returns the offset for the entity eye position\nDefault nil",
     "figura.docs.renderer.set_block_outline_color": "Sets the color of the selected block outline\nDefault alpha is 0.4\nMight not be compatible with shaders",
     "figura.docs.renderer.get_block_outline_color": "Returns the set color for the selected block outline\nDefault nil",
+    "figura.docs.renderer.set_root_rotation_allowed": "Sets if the model should have root rotations applied to it or not\nDefault true",
+    "figura.docs.renderer.get_root_rotation_allowed": "Gets if the model should have root rotations applied",
     "figura.docs.sounds": "A global API which is used to play Minecraft sounds\nAccessed using the name \"sounds\"",
     "figura.docs.sounds.play_sound": "Plays the specified sound at the specified position with the given volume and pitch multipliers\nThe sound id is either an identifier or the custom sound name\nVolume in Minecraft refers to how far away people can hear the sound from, not the actual loudness of it\nIf you don't give values for volume and pitch, the default values are 1",
     "figura.docs.sounds.stop_sound": "Stops the playing sounds from this avatar\nIf an id is specified, it only stops the sounds from that id",


### PR DESCRIPTION
This adds the function `renderer:setRootRotationsAllowed(bool)` to control if the model will have root rotations applied to it.
This includes body yaw, sleeping, swimming, elytra flight, and death.