### PR TITLE
Fixed vanilla inventory behaving odd due to previous pr

### DIFF
--- a/common/src/main/java/org/figuramc/figura/mixin/gui/InventoryScreenMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/gui/InventoryScreenMixin.java
@@ -20,7 +20,7 @@ public class InventoryScreenMixin {
         if (!Configs.FIGURA_INVENTORY.value || AvatarManager.panic)
             return;
 
-        UIHelper.drawEntity(x, y, size, mouseX, mouseY, entity, guiGraphics, EntityRenderMode.MINECRAFT_GUI);
+        UIHelper.drawEntity(x, y, size, mouseY, mouseX, entity, guiGraphics, EntityRenderMode.MINECRAFT_GUI);
         ci.cancel();
     }
 }

--- a/common/src/main/java/org/figuramc/figura/mixin/gui/InventoryScreenMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/gui/InventoryScreenMixin.java
@@ -20,7 +20,7 @@ public class InventoryScreenMixin {
         if (!Configs.FIGURA_INVENTORY.value || AvatarManager.panic)
             return;
 
-        UIHelper.drawEntity(x, y, size, mouseY, mouseX, entity, guiGraphics, EntityRenderMode.MINECRAFT_GUI);
+        UIHelper.drawEntity(x, y, size, (float) Math.atan(mouseY / 40f) * 20f, (float) -Math.atan(mouseX / 40f) * 20f, entity, guiGraphics, EntityRenderMode.MINECRAFT_GUI);
         ci.cancel();
     }
 }

--- a/common/src/main/java/org/figuramc/figura/utils/ui/UIHelper.java
+++ b/common/src/main/java/org/figuramc/figura/utils/ui/UIHelper.java
@@ -177,13 +177,11 @@ public final class UIHelper {
             }
             default -> {
                 // rotations
-                float rot = (float) Math.atan(yaw / 40f) * 20f;
-
-                xRot = (float) Math.atan(pitch / 40f) * 20f;
-                yRot = -rot + bodyY + 180;
+                xRot = pitch;
+                yRot = yaw + bodyY + 180;
 
                 entity.setXRot(-xRot);
-                entity.yHeadRot = rot + bodyY;
+                entity.yHeadRot = -yaw + bodyY;
 
                 // lightning
                 Lighting.setupForEntityInInventory();

--- a/common/src/main/java/org/figuramc/figura/utils/ui/UIHelper.java
+++ b/common/src/main/java/org/figuramc/figura/utils/ui/UIHelper.java
@@ -177,9 +177,9 @@ public final class UIHelper {
             }
             default -> {
                 // rotations
-                float rot = (float) Math.atan(pitch / 40f) * 20f;
+                float rot = (float) Math.atan(yaw / 40f) * 20f;
 
-                xRot = (float) Math.atan(yaw / 40f) * 20f;
+                xRot = (float) Math.atan(pitch / 40f) * 20f;
                 yRot = -rot + bodyY + 180;
 
                 entity.setXRot(-xRot);


### PR DESCRIPTION
*sigh*
look, I do test my prs. Seriously I do.
and for some reason there is *always* this one single trivial thing that somehow goes under the radar.

Anyways, this pr fixes the vanilla inventory being jank from pr #144 and cleans up `UIHelper.drawEntity` a bit.
For some reason, pitch and yaw were being interpreted as mouse coordinates depending on the context. While it made the mixin clean, it made the drawEntity function arguments worse. The pitch and yaw arguments are now always pitch and yaw, regardless of the context.