### PR TITLE
fixed incorrect version used

### DIFF
--- a/common/src/main/java/org/figuramc/figura/backend2/NetworkStuff.java
+++ b/common/src/main/java/org/figuramc/figura/backend2/NetworkStuff.java
@@ -265,14 +265,12 @@ public class NetworkStuff {
         queueString(Util.NIL_UUID, HttpAPI::getVersion, (code, data) -> {
             responseDebug("checkVersion", code, data);
             JsonObject json = JsonParser.parseString(data).getAsJsonObject();
-            latestVersion = new Version(json.get("prerelease").getAsString());
-
             int config = Configs.UPDATE_CHANNEL.value;
-            if (config != 0) {
-                Version compare = config == 1 ? new Version(json.get("release").getAsString()) : latestVersion;
-                if (compare.compareTo(FiguraMod.VERSION) > 0)
-                    FiguraToast.sendToast(FiguraText.of("toast.new_version"), compare);
-            }
+            latestVersion = new Version(json.get(config <= 1 ? "release" : "prerelease").getAsString());
+            if (config == 0)
+                return;
+            if (latestVersion.compareTo(FiguraMod.VERSION) > 0)
+                FiguraToast.sendToast(FiguraText.of("toast.new_version"), latestVersion);
         });
     }
 


### PR DESCRIPTION
This fixes the latest version constantly being the prerelease regardless of the config setting.

A known issue is that after changing the config setting and then going straight to the Wardrobe, the version will not update. Going to a different screen and then going back to the wardrobe then shows the correct version. This is an underlying bug where the Wardrobe screen is initialized before the Settings screen saves it's changes, I think.