### PR TITLE
Redirects prereleases to github releases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ allprojects {
 
 	java_version = rootProject.java_version
 	archivesBaseName = rootProject.archives_base_name
-	version = rootProject.mod_version + "-" + rootProject.minecraft_version
+	version = rootProject.mod_version + "+" + rootProject.minecraft_version
 	group = rootProject.maven_group
 	if (project.hasProperty("release")) {
 		jarVersion = version

--- a/common/src/main/java/org/figuramc/figura/gui/screens/WardrobeScreen.java
+++ b/common/src/main/java/org/figuramc/figura/gui/screens/WardrobeScreen.java
@@ -129,7 +129,12 @@ public class WardrobeScreen extends AbstractPanelScreen {
                             .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
                                     FiguraText.of("gui.new_version.tooltip", Component.literal(NetworkStuff.latestVersion.toString()).withStyle(ChatFormatting.GREEN))
                             ))
-                            .withClickEvent(new TextUtils.FiguraClickEvent(UIHelper.openURL(FiguraMod.Links.Modrinth.url + "/versions")))
+                            .withClickEvent(new TextUtils.FiguraClickEvent(UIHelper.openURL(
+                                NetworkStuff.latestVersion.pre==null ? 
+                                    (FiguraMod.Links.Modrinth.url + "/versions") : 
+                                    (FiguraMod.Links.Github.url + "/releases")
+                                ))
+                            )
                     );
         } else if (versionStatus < 0) {
             versionText.withStyle(Style.EMPTY.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,

--- a/common/src/main/java/org/figuramc/figura/utils/Version.java
+++ b/common/src/main/java/org/figuramc/figura/utils/Version.java
@@ -8,7 +8,16 @@ public class Version implements Comparable<Version> {
     // slightly modified regex of semver
     // difference only is that build metadata can be anything
     // also minor and patch are optionals
-    private static final Pattern PATTERN = Pattern.compile("^(?<major>0|[1-9]\\d*)(?:\\.(?<minor>0|[1-9]\\d*)(?:\\.(?<patch>0|[1-9]\\d*))?)?(?:-(?<pre>(?:0|[1-9]\\d*|\\d*[a-zA-Z-][\\da-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][\\da-zA-Z-]*))*))?(?:\\+(?<build>[\\da-zA-Z-]+(?:\\.[\\da-zA-Z-]+)*))?$");
+    private static final Pattern PATTERN = Pattern.compile(
+        "^"+
+        // #.#.#, with the minor and patch versions being optional.
+        "(?<major>0|[1-9]\\d*)(?:\\.(?<minor>0|[1-9]\\d*)(?:\\.(?<patch>0|[1-9]\\d*))?)?"+
+        // from the -, grab all characters until the +.
+        "(?:-(?<pre>(?:0|[1-9]\\d*|\\d*[a-zA-Z-][\\da-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][\\da-zA-Z-]*))*))?"+
+        // from the +, grab all characters until the end of the string.
+        "(?:\\+(?<build>[\\da-zA-Z-]+(?:\\.[\\da-zA-Z-]+)*))?"+
+        "$"
+    );
 
     private final String src;
 


### PR DESCRIPTION
As we are now releasing prereleases to the github, the "update version" redirect now points to github instead of modrinth, but only when the latest version is identified as a prerelease. Normal relreases are still redirected to modrinth.

Additionally, this fixes a bug where the regex expects the build metadata to begin with a `+`, when the build metadata does not have a `+`. Build metadata was leaking into prerelease data, so this fixes a bug related to version parsing.

Also, I made the version regex span multiple lines so that it will be easier to read in the future.