### PR TITLE
Still allows an avatar to load if none is found for player

### DIFF
--- a/common/src/main/java/org/figuramc/figura/avatar/AvatarManager.java
+++ b/common/src/main/java/org/figuramc/figura/avatar/AvatarManager.java
@@ -153,8 +153,11 @@ public class AvatarManager {
         UUID uuid = entity.getUUID();
 
         // load from player (fetch backend) if is a player
-        if (entity instanceof Player)
-            return getAvatarForPlayer(uuid);
+        if (entity instanceof Player){
+            Avatar avatar = getAvatarForPlayer(uuid);
+            if (avatar != null)
+                return avatar;
+        }
 
         // otherwise check for CEM
         return getAvatarForEntity(entity);


### PR DESCRIPTION
Allows function to continue instead of returning the result of getAvatarForPlayer