### PR TITLE
Client.getEnum

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/ClientAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/ClientAPI.java
@@ -20,6 +20,7 @@ import org.figuramc.figura.lua.LuaNotNil;
 import org.figuramc.figura.lua.LuaWhitelist;
 import org.figuramc.figura.lua.api.entity.EntityAPI;
 import org.figuramc.figura.lua.api.entity.ViewerAPI;
+import org.figuramc.figura.lua.docs.FiguraListDocs;
 import org.figuramc.figura.lua.docs.LuaMethodDoc;
 import org.figuramc.figura.lua.docs.LuaMethodOverload;
 import org.figuramc.figura.lua.docs.LuaTypeDoc;
@@ -618,6 +619,21 @@ public class ClientAPI {
         }
 
         return component.getString();
+    }
+
+    @LuaWhitelist
+    @LuaMethodDoc(
+            overloads = {
+                    @LuaMethodOverload(argumentTypes = String.class, argumentNames = "enumName"),
+            },
+            value = "client.getEnum"
+    )
+    public static List<String> getEnum(@LuaNotNil String enumName) {
+        try {
+            return FiguraListDocs.getEnumValues(enumName);
+        } catch (Exception e) {
+            throw new LuaError("Enum " + enumName + " does not exist");
+        }
     }
 
     @Override

--- a/common/src/main/java/org/figuramc/figura/lua/docs/FiguraListDocs.java
+++ b/common/src/main/java/org/figuramc/figura/lua/docs/FiguraListDocs.java
@@ -292,6 +292,31 @@ public class FiguraListDocs {
         return root;
     }
 
+    public static List<String> getEnumValues(String enumName) {
+        try {
+            ListDoc enumListDoc = ListDoc.valueOf(enumName.toUpperCase());
+
+            Collection<?> enumValues = enumListDoc.get();
+            List<String> enumValueList = new ArrayList<>();
+            for (Object value : enumValues) {
+                if (value instanceof Map.Entry<?, ?> entry) {
+                    enumValueList.add(entry.getKey().toString());
+                    if (entry.getValue() instanceof Collection<?>) {
+                        for (Object alias : (Collection<?>) entry.getValue()) {
+                            enumValueList.add(alias.toString());
+                        }
+                    }
+                } else {
+                    enumValueList.add(value.toString());
+                }
+            }
+
+            return enumValueList;
+        } catch (IllegalArgumentException e) {
+            throw new RuntimeException("Enum " + enumName + " does not exist");
+        }
+    }
+
     public static JsonElement toJson(boolean translate) {
         JsonArray array = new JsonArray();
         for (ListDoc value : ListDoc.values())

--- a/common/src/main/resources/assets/figura/lang/en_us.json
+++ b/common/src/main/resources/assets/figura/lang/en_us.json
@@ -928,6 +928,7 @@
     "figura.docs.client.get_frame_time": "Returns the current fraction between the last tick and the next tick\nThis is the value used as \"delta\" in the RENDER event",
     "figura.docs.client.list_atlases": "Returns a list of all registered atlases paths",
     "figura.docs.client.get_atlas": "Returns a TextureAtlasAPI object with information about the given atlas\nReturns nil if the atlas was not found",
+    "figura.docs.client.get_enum": "Return an array containing the entries in the given enum\nEnums can be found in /figura docs enums",
     "figura.docs.client.get_tab_list": "Returns a table with the text shown in the tablist",
     "figura.docs.client.get_translated_string": "Returns the translated string of the given key\nTranslation is done using the current client language\nOptionally takes a single argument, or a list with all arguments, that will populate the translation",
     "figura.docs.config": "A global API used to save and load avatar data between game sessions",


### PR DESCRIPTION
This PR adds `client.getEnum`, which takes a string and returns a list of values for the Figura enum with that name.

For example, `client.getEnum("render_modes")` returns the table shown in the attached image.

Feel free to close if this change is too intrusive (I think it might break encapsulation for FiguraListDocs?), I don't see a huge use for this feature but it would be nice to have!

![java_YNcC09xuA4](https://github.com/FiguraMC/Figura/assets/50717701/63309a06-70c9-4862-bdc1-3a051c1cc525)