### PR TITLE
Fix particles not being removed

### DIFF
--- a/common/src/main/java/org/figuramc/figura/mixin/particle/ParticleEngineMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/particle/ParticleEngineMixin.java
@@ -28,7 +28,7 @@ public abstract class ParticleEngineMixin implements ParticleEngineAccessor {
     @Unique private final HashMap<Particle, UUID> particleMap = new HashMap<>();
 
     // This fixes a conflict with Optifine having slightly different args + it should be more stable in general, capturing Locals is bad practice
-    @ModifyVariable(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/particle/ParticleEngine;tickParticle(Lnet/minecraft/client/particle/Particle;)V"), method = "tickParticleList", ordinal = 0)
+    @ModifyVariable(method = "tickParticleList", at = @At(value = "INVOKE", target = "Ljava/util/Iterator;remove()V", ordinal = 0))
     private Particle tickParticleList(Particle particle) {
         particleMap.remove(particle);
         return particle;
@@ -50,7 +50,6 @@ public abstract class ParticleEngineMixin implements ParticleEngineAccessor {
         Iterator<Map.Entry<Particle, UUID>> iterator = particleMap.entrySet().iterator();
         while (iterator.hasNext()) {
             Map.Entry<Particle, UUID> entry = iterator.next();
-
             if ((owner == null || entry.getValue().equals(owner))) {
                 if (entry.getKey() != null)
                     entry.getKey().remove();


### PR DESCRIPTION
This should fix an issue that's been around for a while where particles weren't removed on avatar reload, script errors, and `particles:removeParticles()`

The bug was caused by the mixin for tickParticleList targeting `tickParticle`. This immediately and unconditionally removes the particle from `particleMap`, despite the particle still being active. When `figura$clearParticles` is called, `particleMap` is empty and nothing happens.

My fix is to change the mixin to target the `iterator.remove();` call (when the particle is no longer alive), meaning the particle is only removed from `particleMap` when it's actually removed.
