### PR TITLE
Texture:applyMatrix() clipping

### DIFF
--- a/common/src/main/java/org/figuramc/figura/model/rendering/texture/FiguraTexture.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendering/texture/FiguraTexture.java
@@ -312,16 +312,24 @@ public class FiguraTexture extends SimpleTexture {
     @LuaWhitelist
     @LuaMethodDoc(
             overloads = @LuaMethodOverload(
-                    argumentTypes = {Integer.class, Integer.class, Integer.class, Integer.class, FiguraMat4.class},
-                    argumentNames = {"x", "y", "width", "height", "matrix"}
+                    argumentTypes = {Integer.class, Integer.class, Integer.class, Integer.class, FiguraMat4.class, Boolean.class},
+                    argumentNames = {"x", "y", "width", "height", "matrix", "clip"}
             ),
             value = "texture.apply_matrix"
     )
-    public FiguraTexture applyMatrix(int x, int y, int width, int height, @LuaNotNil FiguraMat4 matrix) {
+    public FiguraTexture applyMatrix(int x, int y, int width, int height, @LuaNotNil FiguraMat4 matrix, boolean clip) {
         for (int i = y; i < y + height; i++) {
             for (int j = x; j < x + width; j++) {
                 FiguraVec4 color = getPixel(j, i);
                 color.transform(matrix);
+
+                if (clip) {
+                    color.x = Math.max(0, Math.min(color.x, 1));
+                    color.y = Math.max(0, Math.min(color.y, 1));
+                    color.z = Math.max(0, Math.min(color.z, 1));
+                    color.w = Math.max(0, Math.min(color.w, 1));
+                }
+
                 setPixel(j, i, color, null, null, null);
             }
         }

--- a/common/src/main/resources/assets/figura/lang/en_us.json
+++ b/common/src/main/resources/assets/figura/lang/en_us.json
@@ -1511,7 +1511,7 @@
     "figura.docs.texture.restore": "Restores the texture to its original state, before any modifications",
     "figura.docs.texture.save": "Returns a base64 string representation of this texture",
     "figura.docs.texture.apply_func": "Calls the given function on the specified area of this texture, it will iterate over each pixel, giving its current x, y, and color as arguments, the color is a vec4 in RGBA format, and the return value will set that pixel's color\nInvalid return values or nil takes no effects",
-    "figura.docs.texture.apply_matrix": "Transforms all pixels in the specified area of this texture by the matrix",
+    "figura.docs.texture.apply_matrix": "Transforms all pixels in the specified area of this texture by the matrix\nIf `clip` is true, the resulting colour channels will be clamped between 0 and 1",
     "figura.docs.texture_atlas": "A texture atlas object, with helper functions related to a texture atlas",
     "figura.docs.texture_atlas.list_sprites": "Returns a table with all sprite paths under this atlas",
     "figura.docs.texture_atlas.get_sprite_uv": "Returns a vec4 containing the UV of the given sprite\nThe UV is ordered as U0, V0, U1, V1",


### PR DESCRIPTION
This PR adds a new field to Texture:applyMatrix(), `clip`, which clamps the resulting colours' channels between 0 and 1.