### PR TITLE
Retry saving config files

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/ConfigAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/ConfigAPI.java
@@ -79,7 +79,7 @@ public class ConfigAPI {
         }
     }
 
-    private void writeWithRetries(Path path, byte[] data, int retries) {
+    private void writeWithRetries(Path path, byte[] data, int retries) throws Exception {
         try (OutputStream fs = Files.newOutputStream(path)) {
 
         } catch (Exception e) {

--- a/common/src/main/java/org/figuramc/figura/lua/api/ConfigAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/ConfigAPI.java
@@ -79,7 +79,7 @@ public class ConfigAPI {
         }
     }
 
-    private void writeWithRetries(String path, byte[] data, int retries) {
+    private void writeWithRetries(Path path, byte[] data, int retries) {
         try (OutputStream fs = Files.newOutputStream(path)) {
 
         } catch (Exception e) {
@@ -107,7 +107,7 @@ public class ConfigAPI {
             writeWithRetries(path, GSON.toJson(root).getBytes(), 5);
         } catch (Exception e) {
             FiguraMod.LOGGER.error("", e);
-            throw new LuaError("Really failed to save avatar data file: " + e);
+            throw new LuaError("Failed to save avatar data file: " + e);
         }
     }
 

--- a/common/src/main/java/org/figuramc/figura/lua/api/ConfigAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/ConfigAPI.java
@@ -79,6 +79,19 @@ public class ConfigAPI {
         }
     }
 
+    private void writeWithRetries(String path, byte[] data, int retries) {
+        try (OutputStream fs = Files.newOutputStream(path)) {
+
+        } catch (Exception e) {
+            if (retries > 0) {
+                Thread.sleep(5); // this feels suspicious, but it shouldn't be noticable (25ms at most, and only on save)
+                writeWithRetries(path, data, retries - 1);
+            } else {
+                throw e;
+            }
+        }
+    }
+        
     // write
     private void write() {
         // parse file target
@@ -90,11 +103,11 @@ public class ConfigAPI {
             root.add(key.toString(), writeArg(luaTable.get(key), new JsonObject()));
 
         // write file
-        try (OutputStream fs = Files.newOutputStream(path)) {
-            fs.write(GSON.toJson(root).getBytes());
+        try {
+            writeWithRetries(path, GSON.toJson(root).getBytes(), 5);
         } catch (Exception e) {
             FiguraMod.LOGGER.error("", e);
-            throw new LuaError("Failed to save avatar data file");
+            throw new LuaError("Really failed to save avatar data file: " + e);
         }
     }
 

--- a/common/src/main/java/org/figuramc/figura/lua/api/ConfigAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/ConfigAPI.java
@@ -81,7 +81,7 @@ public class ConfigAPI {
 
     private void writeWithRetries(Path path, byte[] data, int retries) throws Exception {
         try (OutputStream fs = Files.newOutputStream(path)) {
-
+            fs.write(data);    
         } catch (Exception e) {
             if (retries > 0) {
                 Thread.sleep(5); // this feels suspicious, but it shouldn't be noticable (25ms at most, and only on save)


### PR DESCRIPTION
Contains a questionable Thread.sleep but it's capped to 25ms and should otherwise be fine. Also exposes the error message to the user.