### PR TITLE
Fixed Chat Customizations Config from disabling all

### DIFF
--- a/common/src/main/java/org/figuramc/figura/mixin/gui/ChatComponentMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/gui/ChatComponentMixin.java
@@ -127,9 +127,9 @@ public class ChatComponentMixin {
             message = TextUtils.replaceInText(message, quotedName, emptyReplacement, (s, style) -> true, isOwner ? 1 : 0, Integer.MAX_VALUE);
 
             // sender badges
-            if (config > 1 && isOwner) {
+            if (isOwner) {
                 // badges
-                Component temp = Badges.appendBadges(replacement, uuid, true);
+                Component temp = Badges.appendBadges(replacement, uuid, config > 1);
                 // trim
                 temp = TextUtils.trim(temp);
                 // modify message, only first


### PR DESCRIPTION
This fixes the issue where when Chat Customizations is set to Script (disable badges), it would prevent the sender of the message from having their username changed.
Specifically, it was the first instance, which is typically in the `<>`. All instances after that were fine.
![image](https://github.com/FiguraMC/Figura/assets/94943674/63d4eab8-e1a5-4763-9be3-d17e2e886217)

Anyways, its fixed now. 
Someone should probably go over `ChatComponentMixin.java` at some point, as it feels highly prone to error with the `Owner` nonsense

Fixes [nameplate is not applied only in chat customization script](https://discord.com/channels/1129805506354085959/1214870746765983815) and [Figura badge/script toggle in chat broken](https://discord.com/channels/1129805506354085959/1187435993138216971)