### PR TITLE
Ignore file changes in hidden folders

### DIFF
--- a/common/src/main/java/org/figuramc/figura/avatar/local/LocalAvatarLoader.java
+++ b/common/src/main/java/org/figuramc/figura/avatar/local/LocalAvatarLoader.java
@@ -15,7 +15,10 @@ import org.figuramc.figura.utils.FiguraResourceListener;
 import org.figuramc.figura.utils.FiguraText;
 import org.figuramc.figura.utils.IOUtils;
 
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -310,7 +313,7 @@ public class LocalAvatarLoader {
                 Path path = entry.getKey().resolve((Path) event.context());
                 String name = IOUtils.getFileNameOrEmpty(path);
 
-                if (IOUtils.isHidden(path) || !(Files.isDirectory(path) || name.matches("(.*(\\.lua|\\.bbmodel|\\.ogg|\\.png)$|avatar\\.json)")))
+                if (IOUtils.isHiddenAvatarResource(path) || !(Files.isDirectory(path) || name.matches("(.*(\\.lua|\\.bbmodel|\\.ogg|\\.png)$|avatar\\.json)")))
                     continue;
 
                 if (kind == StandardWatchEventKinds.ENTRY_CREATE && !IS_WINDOWS)


### PR DESCRIPTION
# Bug
Figura would trigger Model autoreload, even if a file withing a *hidden* directory was changed. It used to happen, as Figura only checked, if a file itself is hidden, and did not check, if the file is contained within a hidden directory. This used to lead to multiple unneeded autoreloads and high resources usage.

![image](https://github.com/FiguraMC/Figura/assets/76918084/75845960-bedb-461c-9841-48ba7e752719)

## Solution
- Added `IOUtils#isHiddenAvatarResource(Path)` static method, that checks both, if the file itself is hidden, or if it is contained within a hidden folder.
- Made `LocalAvatarLoader#tick()` use new `IOUtils#isHiddenAvatarResource(Path)` instead of `Files#isHidden(Path)`.