### PR TITLE
TOTEM event

### DIFF
--- a/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
+++ b/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
@@ -477,6 +477,10 @@ public class Avatar {
         if (loaded) run("CHAR_TYPED", tick, chars, modifiers, codePoint);
     }
 
+    public boolean totemEvent() {
+        return isCancelled(loaded ? run("TOTEM",tick) : null);
+    }
+
     // -- rendering events -- // 
 
     private void render() {

--- a/common/src/main/java/org/figuramc/figura/lua/api/event/EventsAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/event/EventsAPI.java
@@ -87,6 +87,9 @@ public class EventsAPI {
     @LuaWhitelist
     @LuaFieldDoc("events.resource_reload")
     public final LuaEvent RESOURCE_RELOAD = new LuaEvent();
+    @LuaWhitelist
+    @LuaFieldDoc("events.totem")
+    public final LuaEvent TOTEM = new LuaEvent();
 
     private final Map<String, LuaEvent> events = new HashMap<>();
     
@@ -112,6 +115,7 @@ public class EventsAPI {
         events.put("ITEM_RENDER", ITEM_RENDER);
         events.put("ON_PLAY_SOUND", ON_PLAY_SOUND);
         events.put("RESOURCE_RELOAD", RESOURCE_RELOAD);
+        events.put("TOTEM", TOTEM);
 
         for (FiguraEvent entrypoint : ENTRYPOINTS) {
             String ID = entrypoint.getID().toUpperCase(Locale.US);

--- a/common/src/main/java/org/figuramc/figura/mixin/ClientPacketListenerMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/ClientPacketListenerMixin.java
@@ -1,18 +1,35 @@
 package org.figuramc.figura.mixin;
 
+import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.network.protocol.game.ClientboundEntityEventPacket;
+import net.minecraft.world.level.Level;
 import org.figuramc.figura.FiguraMod;
+import org.figuramc.figura.avatar.Avatar;
+import org.figuramc.figura.avatar.AvatarManager;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = ClientPacketListener.class, priority = 999)
-public class ClientPacketListenerMixin {
+public abstract class ClientPacketListenerMixin {
+
+    @Shadow public abstract ClientLevel getLevel();
 
     @Inject(at = @At("HEAD"), method = "sendUnsignedCommand", cancellable = true)
     private void sendUnsignedCommand(String command, CallbackInfoReturnable<Boolean> cir) {
         if (command.startsWith(FiguraMod.MOD_ID))
             cir.setReturnValue(false);
+    }
+
+    @Inject(method = "handleEntityEvent", at = @At(value = "FIELD", target = "Lnet/minecraft/core/particles/ParticleTypes;TOTEM_OF_UNDYING:Lnet/minecraft/core/particles/SimpleParticleType;"), cancellable = true)
+    private void handleTotem(ClientboundEntityEventPacket packet, CallbackInfo ci) {
+        Level level = getLevel();
+        Avatar avatar = AvatarManager.getAvatar(packet.getEntity(level));
+        if (avatar != null && avatar.totemEvent())
+            ci.cancel();
     }
 }

--- a/common/src/main/resources/assets/figura/lang/en_us.json
+++ b/common/src/main/resources/assets/figura/lang/en_us.json
@@ -1060,6 +1060,7 @@
     "figura.docs.events.item_render": "Called on every one of your items that is being rendered\nIt takes six arguments: the item being rendered, the rendering mode, the position, rotation, and scale that would be applied to the item, and if it's being rendered in the left hand\nReturning a ModelPart parented to Item stops the rendering of this item and will render the returned part instead",
     "figura.docs.events.on_play_sound": "Called every time a new sound is played\nTakes the following as arguments: the sound's ID, its world position, volume, pitch, if the sound should loop, the sound's category, and the sound's file path\nReturn true to prevent this sound from playing",
     "figura.docs.events.resource_reload": "Called every time that the client resources are reloaded, allowing you to re-create or update resource texture references",
+    "figura.docs.events.totem": "Called whenever you use a Totem of Undying to cheat death\nIf returned true the animation is cancelled",
     "figura.docs.events.get_events": "Returns a table with all events types",
     "figura.docs.event": "A hook for a certain event in Minecraft\nYou may register functions to one, and those functions will be called when the event occurs",
     "figura.docs.event.register": "Register a function on this event\nFunctions are run in registration order\nAn optional string argument can be given, grouping functions under that name, for an easier management later on",


### PR DESCRIPTION
Fires whenever a player uses a Totem of Undying.
If the event is returned true, it will cancel the animation.