### PR TITLE
Fixed removal of "separate" parts

### DIFF
--- a/common/src/main/java/org/figuramc/figura/model/FiguraModelPart.java
+++ b/common/src/main/java/org/figuramc/figura/model/FiguraModelPart.java
@@ -1413,6 +1413,9 @@ public class FiguraModelPart implements Comparable<FiguraModelPart> {
         if(part.childCache.get(this.name) == null)
             part.childCache.put(this.name, this);
         this.parent = part;
+
+        if (this.parentType.isSeparate)
+            owner.renderer.sortParts();
         return this;
     }
 
@@ -1438,6 +1441,10 @@ public class FiguraModelPart implements Comparable<FiguraModelPart> {
         if(this.childCache.get(part.name) == null)
             this.childCache.put(part.name, part);
         part.parent = this;
+
+        if (part.parentType.isSeparate)
+            owner.renderer.sortParts();
+
         return this;
     }
 
@@ -1454,6 +1461,10 @@ public class FiguraModelPart implements Comparable<FiguraModelPart> {
             this.children.remove(part);
             this.childCache.remove(part.name);
             part.parent = null;
+
+            // Since any part arbitrarily down the tree could have a parent
+            // type marked as separate, this is pretty much required.
+            owner.renderer.sortParts();
         }
         return this;
     }


### PR DESCRIPTION
This fixes issues involving removal or addition of parts with parent types considered "separate." (World, Hud, Elytra, etc.)
This is done by running `AvatarRenderer.sortParts()` when it should be run.

Basic testing was done and it seems to work for every case I gave it.

Due to the nature of this bug, `FiguraModelPart.removeChild()` always has to sort parts again even if the child being removed is not separate because that child could contain a child that *is* separate (and so on.)  
If anyone has a better solution feel free to do whatever.

***

This bug caused world parts to continue to be rendered even after being removed with `:remove()` or not render at all if added with `:moveTo()` or `:addChild()`.

The easiest way to test this bug is to create a model with the structure `root > World > cube` and then remove root:
```lua
function show_bug()
  models.model.root:remove()
end
```
Note how the cube is still visible after removal.

Using the same structure, the other side of the bug can be shown:
```lua
function show_bug2()
  local copy = models.model.root.World:copy("foo")
  copy:setPos(16, 0, 0) -- move the copy so it doesn't intersect with the original
  copy:moveTo(models.model.root)
end
```
A second cube should not appear.

In 0.1.4, this issue can be avoided by first setting the parent type of parts that this bug affects to `"None"` before doing these operations. The parent type can be set back after the operations are completed.
