### PR TITLE
Include port for backend SERVER_IP

### DIFF
--- a/common/src/main/java/org/figuramc/figura/backend2/HttpAPI.java
+++ b/common/src/main/java/org/figuramc/figura/backend2/HttpAPI.java
@@ -29,8 +29,18 @@ public class HttpAPI {
     }
 
     protected static String getBackendAddress() {
+        return "https://" + getBackendAddressWithPort() + "/api";
+    }
+
+    private static String getBackendAddressWithPort() {
         ServerAddress backendIP = ServerAddress.parseString(Configs.SERVER_IP.value);
-        return "https://" + backendIP.getHost() + "/api";
+        boolean hasPort = Configs.SERVER_IP.value.matches("[^:]+:\\d+");
+        if (hasPort) {
+            try {
+                return backendIP.getHost() + ":" + backendIP.getPort();
+            } catch (IllegalStateException ignored) { }
+        }
+        return backendIP.getHost();
     }
 
     protected HttpRequest.Builder header(String url) {

--- a/common/src/main/java/org/figuramc/figura/backend2/websocket/FiguraWebSocketAdapter.java
+++ b/common/src/main/java/org/figuramc/figura/backend2/websocket/FiguraWebSocketAdapter.java
@@ -55,8 +55,18 @@ public class FiguraWebSocketAdapter extends WebSocketAdapter {
     }
 
     public static String getBackendAddress() {
+        return "wss://" + getBackendAddressWithPort() + "/ws";
+    }
+
+    private static String getBackendAddressWithPort() {
         ServerAddress backendIP = ServerAddress.parseString(Configs.SERVER_IP.value);
-        return "wss://" + backendIP.getHost() + "/ws";
+        boolean hasPort = Configs.SERVER_IP.value.matches("[^:]+:\\d+");
+        if (hasPort) {
+            try {
+                return backendIP.getHost() + ":" + backendIP.getPort();
+            } catch (IllegalStateException ignored) { }
+        }
+        return backendIP.getHost();
     }
 
     @Override


### PR DESCRIPTION
I've been working on developing the backend for Figura clients. For additional context, please refer to issue #239.

The backend setup is nearly complete, but I'm encountering a problem where the client doesn't retain the specified port. While this may not seem critical, it becomes an issue when using a server hosting service. Without proper port forwarding, which must be handled by the server host, the client is unable to access the necessary port. Specifically, the client requires port 443 to function, and currently, the mod/plugin is restricted to using only this port. This also necessitates running the application with administrative permissions.

This pull request addresses the port retention issue, allowing the mod/plugin to be used on ports other than 443. This fix will enable me to continue developing and testing the backend in a production environment.

If you would like to review the code, please refer to my repository: [https://github.com/Leialoha/Figura-Backend-Server](https://github.com/Leialoha/Figura-Backend-Server).