### PR TITLE
Texture fix for BB4.9- models in zips

### DIFF
--- a/common/src/main/java/org/figuramc/figura/parsers/BlockbenchModelParser.java
+++ b/common/src/main/java/org/figuramc/figura/parsers/BlockbenchModelParser.java
@@ -11,6 +11,7 @@ import org.figuramc.figura.FiguraMod;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -130,34 +131,31 @@ public class BlockbenchModelParser {
             String path;
             byte[] source;
             try {
-                //check the file to load
+                // Check the file to load
                 Path p = sourceFile.getParent().resolve(texture.relative_path);
-                if (p.getFileSystem() == FileSystems.getDefault()) {
-                    File f = p.toFile().getCanonicalFile();
-                    p = f.toPath();
-                    if (!f.exists()) {
-                        // Compatibility with old Blockbench models. (BB 4.9-)
-                        if (texture.relative_path.startsWith("../")) {
-                            p = sourceFile.resolve(texture.relative_path);
-                            if (p.getFileSystem() == FileSystems.getDefault()) {
-                                f = p.toFile().getCanonicalFile();
-                                p = f.toPath();
-                                if (!f.exists()) throw new IllegalStateException("File do not exists!");
-                            } else {
-                                p = p.normalize();
-                                if (p.getFileSystem() != avatar.getFileSystem())
-                                    throw new IllegalStateException("File from outside the avatar folder!");
-                            }
-                        } else {
-                            throw new IllegalStateException("File do not exists!");
-                        }
+                if (p.getFileSystem() == FileSystems.getDefault())
+                    p = p.toFile().getCanonicalFile().toPath();
+
+                if (!Files.exists(p)) {
+                    // Compatibility with old Blockbench models. (BB 4.9-)
+                    if (texture.relative_path.startsWith("../")) {
+                        p = sourceFile.resolve(texture.relative_path);
+                        if (p.getFileSystem() == FileSystems.getDefault())
+                            p = p.toFile().getCanonicalFile().toPath();
+
+                        if (!Files.exists(p))
+                            throw new IllegalStateException("File does not exist!");
+                    } else {
+                        throw new IllegalStateException("File does not exist!");
                     }
-                } else {
-                    p = p.normalize();
-                    if (p.getFileSystem() != avatar.getFileSystem())
-                        throw new IllegalStateException("File from outside the avatar folder!");
                 }
-                if (avatar.getNameCount() > 1) if (!p.startsWith(avatar)) throw new IllegalStateException("File from outside the avatar folder!");
+
+                p = p.normalize();
+
+                // Make sure we are still looking in the avatar's folder
+                if ((avatar.getNameCount() > 1 && !p.startsWith(avatar)) || p.getFileSystem() != avatar.getFileSystem())
+                    throw new IllegalStateException("File from outside the avatar folder!");
+
                 FiguraMod.debug("path is {}", p.toString());
                 //load texture
                 source = IOUtils.readFileBytes(p);

--- a/common/src/main/java/org/figuramc/figura/parsers/BlockbenchModelParser.java
+++ b/common/src/main/java/org/figuramc/figura/parsers/BlockbenchModelParser.java
@@ -136,12 +136,16 @@ public class BlockbenchModelParser {
                 if (p.getFileSystem() == FileSystems.getDefault())
                     p = p.toFile().getCanonicalFile().toPath();
 
-                if (!Files.exists(p)) {
+                p = p.normalize();
+
+                if (!Files.exists(p) || (avatar.getNameCount() > 1 && !p.startsWith(avatar))) {
                     // Compatibility with old Blockbench models. (BB 4.9-)
                     if (texture.relative_path.startsWith("../")) {
                         p = sourceFile.resolve(texture.relative_path);
                         if (p.getFileSystem() == FileSystems.getDefault())
                             p = p.toFile().getCanonicalFile().toPath();
+
+                        p = p.normalize();
 
                         if (!Files.exists(p))
                             throw new IllegalStateException("File does not exist!");
@@ -150,7 +154,6 @@ public class BlockbenchModelParser {
                     }
                 }
 
-                p = p.normalize();
 
                 // Make sure we are still looking in the avatar's folder
                 if ((avatar.getNameCount() > 1 && !p.startsWith(avatar)) || p.getFileSystem() != avatar.getFileSystem())


### PR DESCRIPTION
This also rewrites the section that determines where to find the file for a texture to be less of a mess. (Hopefully)

Fixes https://discord.com/channels/1129805506354085959/1259403610639437834/1270695674194825279
> the textures in avatars in zip files are not readed correctly
> it looks like the texture is only readed from model and the figura doesnt check if the texture actually exists as file
> first image shows normal behaviour when avatar is not zipped
> second shows texture being readed only from model
> also made this simple avatar to test the bug (need to unzip it to see it working correctly)
> > *Attached were two images showing the error and a link to a zip file to test the error*

***

This was tested with avatars both zipped and unzipped that attempted to:
* get a texture one folder up (BB4.9- behavior)
* get a texture two folders up
* get the root of the file system

All failed to break out of the avatar's folder and the first one succeeded in finding a local texture file when zipped. (Which #235 fixed with unzipped avatars.)