### PR TITLE
Fixes a crash caused by __newindex in _G

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/FiguraLuaRuntime.java
+++ b/common/src/main/java/org/figuramc/figura/lua/FiguraLuaRuntime.java
@@ -102,7 +102,7 @@ public class FiguraLuaRuntime {
     }
 
     public void setGlobal(String name, Object obj) {
-        userGlobals.set(name, typeManager.javaToLua(obj).arg1());
+        userGlobals.rawset(name, typeManager.javaToLua(obj).arg1());
     }
 
     public void setUser(Entity user) {
@@ -114,8 +114,8 @@ public class FiguraLuaRuntime {
             val = entityAPI = EntityAPI.wrap(user);
         }
 
-        userGlobals.set("user", typeManager.javaToLua(val).arg1());
-        userGlobals.set("player", userGlobals.get("user"));
+        userGlobals.rawset("user", typeManager.javaToLua(val).arg1());
+        userGlobals.rawset("player", userGlobals.rawget("user"));
     }
 
     public Entity getUser() {


### PR DESCRIPTION
When Figura adds `player` to the environment, it does not do so with raw methods, allowing others to catch it in an unprotected context.

***

Throwing an error in Lua in an unprotected context will cause a game crash if it isn't caught somewhere in Java.

This changes some instances of `userGlobals.get` and `userGlobals.set` to their raw counterparts to avoid this.

Fixes https://discord.com/channels/1129805506354085959/1263490063694561311