### PR TITLE
Fix cursed string caching bug w/ AST builder

### DIFF
--- a/common/src/main/java/org/figuramc/figura/parsers/LuaScriptBuilderVisitor.java
+++ b/common/src/main/java/org/figuramc/figura/parsers/LuaScriptBuilderVisitor.java
@@ -294,7 +294,7 @@ public class LuaScriptBuilderVisitor extends Visitor {
     public void visit(Exp.Constant exp) {
         LuaValue value = exp.value;
         if (value instanceof LuaString str) {
-            String input = new String(str.m_bytes, StandardCharsets.UTF_8);
+            String input = new String(str.m_bytes, str.m_offset, str.m_length, StandardCharsets.UTF_8);
             int sdq = 0;
             for (char c : input.toCharArray()) {
                 if (c == '\'') sdq--;


### PR DESCRIPTION
bug report: https://discord.com/channels/1129805506354085959/1280443716460482560
tested with:
```lua
local CURSED_TABLE = {
   ["minecraft:iron"] = true
}

function events.entity_init()
   ("minecraft:iron_chestplate"):match('[^_]+')
   models:setUVPixels(0, 0)
end

print((next(CURSED_TABLE)))
```

[multitarget build (cherry-pick)](https://github.com/penguinencounter/Figura/actions/runs/10711085030) (has 1.16.5 merge conflicts)