### PR TITLE
implement get xp for next level

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/entity/PlayerAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/entity/PlayerAPI.java
@@ -78,6 +78,13 @@ public class PlayerAPI extends LivingEntityAPI<Player> {
     }
 
     @LuaWhitelist
+    @LuaMethodDoc("player.get_xp_for_next_level")
+    public int getExperienceForNextLevel(){
+        checkEntity();
+        return entity.getXpNeededForNextLevel();
+    }
+
+    @LuaWhitelist
     @LuaMethodDoc("player.get_experience_level")
     public int getExperienceLevel() {
         checkEntity();

--- a/common/src/main/resources/assets/figura/lang/en_us.json
+++ b/common/src/main/resources/assets/figura/lang/en_us.json
@@ -1029,6 +1029,7 @@
     "figura.docs.player.get_saturation": "Gets the current saturation level of the player",
     "figura.docs.player.get_exhaustion": "Gets the current exhaustion level of the player",
     "figura.docs.player.get_experience_progress": "Gets the progress of the way towards the player's next level, as a value from 0 to 1",
+    "player.get_xp_for_next_level": "Gets the amount of experience needed to level up",
     "figura.docs.player.get_experience_level": "Gets the player's current level",
     "figura.docs.player.get_model_type": "Returns \"SLIM\" or \"DEFAULT\", depending on the player's model type",
     "figura.docs.player.get_gamemode": "Returns \"SURVIVAL\", \"CREATIVE\", \"ADVENTURE\", or \"SPECTATOR\" depending on the player's gamemode\nIf the gamemode is unknown, returns nil",


### PR DESCRIPTION
gets the amount of xp until you gain a level, as an experience amount

makes working out your raw xp value much easier when combined with getting progress