### PR TITLE
unfeat: remove default permissions

### DIFF
--- a/common/src/main/java/org/figuramc/figura/backend2/NetworkStuff.java
+++ b/common/src/main/java/org/figuramc/figura/backend2/NetworkStuff.java
@@ -335,13 +335,6 @@ public class NetworkStuff {
             for (int i = 0; i < special.size(); i++)
                 specialSet.set(i, special.get(i).getAsInt() >= 1);
 
-            //default permission
-            JsonElement trust = json.get("trust");
-            if (trust != null) {
-                Permissions.Category cat = Permissions.Category.indexOf(trust.getAsInt());
-                if (cat != null) PermissionManager.setDefaultFor(user.id, cat);
-            }
-
             user.loadData(avatars, badgesPair);
         });
     }


### PR DESCRIPTION
removes the old backend permission system left behind by F, which doesn't respect user config
