### PR TITLE
fix(colors): rename colors that conflict with figura

### DIFF
--- a/common/src/main/java/org/figuramc/figura/config/Configs.java
+++ b/common/src/main/java/org/figuramc/figura/config/Configs.java
@@ -136,7 +136,7 @@ public class Configs {
                 String tooltip = "config.render_debug_parts_pivot.tooltip";
                 this.tooltip = FiguraText.of(tooltip,
                         FiguraText.of(tooltip + ".cubes").setStyle(ColorUtils.Colors.AWESOME_BLUE.style),
-                        FiguraText.of(tooltip + ".groups").setStyle(ColorUtils.Colors.BLUE.style));
+                        FiguraText.of(tooltip + ".groups").setStyle(ColorUtils.Colors.FIGURA_BLUE.style));
             }};
     public static final ConfigType.BoolConfig
             ALLOW_FP_HANDS = new ConfigType.BoolConfig("allow_fp_hands", RENDERING, false),

--- a/common/src/main/java/org/figuramc/figura/lua/FiguraLuaPrinter.java
+++ b/common/src/main/java/org/figuramc/figura/lua/FiguraLuaPrinter.java
@@ -348,7 +348,7 @@ public class FiguraLuaPrinter {
         if (value.istable())
             return ColorUtils.Colors.AWESOME_BLUE.style;
         else if (!(value instanceof LuaString) && value.isnumber())
-            return ColorUtils.Colors.BLUE.style;
+            return ColorUtils.Colors.FIGURA_BLUE.style;
         else if (value.isnil())
             return ColorUtils.Colors.LUA_ERROR.style;
         else if (value.isboolean())

--- a/common/src/main/java/org/figuramc/figura/lua/docs/FiguraDoc.java
+++ b/common/src/main/java/org/figuramc/figura/lua/docs/FiguraDoc.java
@@ -55,7 +55,7 @@ public abstract class FiguraDoc {
     public static int printRoot() {
         FiguraMod.sendChatMessage(HEADER.copy()
                 .append("\n\n")
-                .append(FiguraText.of("docs").withStyle(ColorUtils.Colors.BLUE.style)));
+                .append(FiguraText.of("docs").withStyle(ColorUtils.Colors.FIGURA_BLUE.style)));
 
         return 1;
     }
@@ -134,7 +134,7 @@ public abstract class FiguraDoc {
 
             // type
             message.append("\n\t")
-                    .append(Component.literal("• " + name).withStyle(ColorUtils.Colors.BLUE.style));
+                    .append(Component.literal("• " + name).withStyle(ColorUtils.Colors.FIGURA_BLUE.style));
 
             if (superclass != null) {
                 message.append(" (")
@@ -151,7 +151,7 @@ public abstract class FiguraDoc {
                             .append(":")
                             .withStyle(ColorUtils.Colors.PURPLE.style));
 
-            MutableComponent descText = Component.empty().withStyle(ColorUtils.Colors.BLUE.style);
+            MutableComponent descText = Component.empty().withStyle(ColorUtils.Colors.FIGURA_BLUE.style);
             for (Component component : TextUtils.splitText(FiguraText.of("docs." + description), "\n"))
                 descText.append("\n\t").append("• ").append(component);
             message.append(descText);
@@ -242,7 +242,7 @@ public abstract class FiguraDoc {
                             .append(":")
                             .withStyle(ColorUtils.Colors.PURPLE.style))
                     .append("\n\t")
-                    .append(Component.literal("• " + name).withStyle(ColorUtils.Colors.BLUE.style));
+                    .append(Component.literal("• " + name).withStyle(ColorUtils.Colors.FIGURA_BLUE.style));
 
             // aliases
             if (aliases.length > 0) {
@@ -256,7 +256,7 @@ public abstract class FiguraDoc {
                     message.append("\n\t")
                             .append(Component.literal("• ")
                                     .append(alias)
-                                    .withStyle(ColorUtils.Colors.BLUE.style));
+                                    .withStyle(ColorUtils.Colors.FIGURA_BLUE.style));
                 }
             }
 
@@ -271,10 +271,10 @@ public abstract class FiguraDoc {
 
                 // name
                 message.append("\n\t")
-                        .append(Component.literal("• ").withStyle(ColorUtils.Colors.BLUE.style))
+                        .append(Component.literal("• ").withStyle(ColorUtils.Colors.FIGURA_BLUE.style))
                         .append(Component.literal("<" + typeName + ">").withStyle(ChatFormatting.YELLOW))
                         .append(Component.literal(isStatic ? "." : ":").withStyle(ChatFormatting.BOLD))
-                        .append(Component.literal(name).withStyle(ColorUtils.Colors.BLUE.style))
+                        .append(Component.literal(name).withStyle(ColorUtils.Colors.FIGURA_BLUE.style))
                         .append("(");
 
                 for (int j = 0; j < parameterTypes[i].length; j++) {
@@ -289,7 +289,7 @@ public abstract class FiguraDoc {
 
                 // return
                 message.append(") → ")
-                        .append(FiguraText.of("docs.text.returns").append(" ").withStyle(ColorUtils.Colors.BLUE.style))
+                        .append(FiguraText.of("docs.text.returns").append(" ").withStyle(ColorUtils.Colors.FIGURA_BLUE.style))
                         .append(FiguraDocsManager.getClassText(returnTypes[i]).withStyle(ChatFormatting.YELLOW));
             }
 
@@ -300,7 +300,7 @@ public abstract class FiguraDoc {
                             .append(":")
                             .withStyle(ColorUtils.Colors.PURPLE.style));
 
-            MutableComponent descText = Component.empty().withStyle(ColorUtils.Colors.BLUE.style);
+            MutableComponent descText = Component.empty().withStyle(ColorUtils.Colors.FIGURA_BLUE.style);
             for (Component component : TextUtils.splitText(FiguraText.of("docs." + description), "\n"))
                 descText.append("\n\t").append("• ").append(component);
             message.append(descText);
@@ -386,9 +386,9 @@ public abstract class FiguraDoc {
                             .append(":")
                             .withStyle(ColorUtils.Colors.PURPLE.style))
                     .append("\n\t")
-                    .append(Component.literal("• ").withStyle(ColorUtils.Colors.BLUE.style))
+                    .append(Component.literal("• ").withStyle(ColorUtils.Colors.FIGURA_BLUE.style))
                     .append(FiguraDocsManager.getClassText(type).withStyle(ChatFormatting.YELLOW))
-                    .append(Component.literal(" " + name).withStyle(ColorUtils.Colors.BLUE.style))
+                    .append(Component.literal(" " + name).withStyle(ColorUtils.Colors.FIGURA_BLUE.style))
                     .append(Component.literal(" (")
                             .append(FiguraText.of(editable ? "docs.text.editable" : "docs.text.not_editable"))
                             .append(")")
@@ -401,7 +401,7 @@ public abstract class FiguraDoc {
                             .append(":")
                             .withStyle(ColorUtils.Colors.PURPLE.style));
 
-            MutableComponent descText = Component.empty().withStyle(ColorUtils.Colors.BLUE.style);
+            MutableComponent descText = Component.empty().withStyle(ColorUtils.Colors.FIGURA_BLUE.style);
             for (Component component : TextUtils.splitText(FiguraText.of("docs." + description), "\n"))
                 descText.append("\n\t").append("• ").append(component);
             message.append(descText);

--- a/common/src/main/java/org/figuramc/figura/lua/docs/FiguraListDocs.java
+++ b/common/src/main/java/org/figuramc/figura/lua/docs/FiguraListDocs.java
@@ -209,7 +209,7 @@ public class FiguraListDocs {
                         .append("\n\t")
                         .append(Component.literal("• ")
                                 .append(FiguraText.of("docs.enum." + id))
-                                .withStyle(ColorUtils.Colors.BLUE.style))
+                                .withStyle(ColorUtils.Colors.FIGURA_BLUE.style))
                         .append("\n\n")
                         .append(Component.literal("• ")
                                 .append(FiguraText.of("docs.text.entries"))
@@ -283,7 +283,7 @@ public class FiguraListDocs {
                     .append("\n\t")
                     .append(Component.literal("• ")
                             .append(Component.literal("enumerators"))
-                            .withStyle(ColorUtils.Colors.BLUE.style))
+                            .withStyle(ColorUtils.Colors.FIGURA_BLUE.style))
 
                     .append("\n\n")
                     .append(Component.literal("• ")
@@ -293,7 +293,7 @@ public class FiguraListDocs {
                     .append("\n\t")
                     .append(Component.literal("• ")
                             .append(FiguraText.of("docs.enum"))
-                            .withStyle(ColorUtils.Colors.BLUE.style))
+                            .withStyle(ColorUtils.Colors.FIGURA_BLUE.style))
             );
             return 1;
         });

--- a/common/src/main/java/org/figuramc/figura/model/rendering/ImmediateAvatarRenderer.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendering/ImmediateAvatarRenderer.java
@@ -387,7 +387,7 @@ public class ImmediateAvatarRenderer extends AvatarRenderer {
 
     protected void renderPivot(FiguraModelPart part, PartCustomization customization) {
         boolean group = part.customization.partType == PartCustomization.PartType.GROUP;
-        FiguraVec3 color = group ? ColorUtils.Colors.BLUE.vec : ColorUtils.Colors.AWESOME_BLUE.vec;
+        FiguraVec3 color = group ? ColorUtils.Colors.FIGURA_BLUE.vec : ColorUtils.Colors.AWESOME_BLUE.vec;
         double boxSize = group ? 1 / 16d : 1 / 32d;
         boxSize /= Math.max(Math.cbrt(part.savedPartToWorldMat.det()), 0.02);
 

--- a/common/src/main/java/org/figuramc/figura/utils/ColorUtils.java
+++ b/common/src/main/java/org/figuramc/figura/utils/ColorUtils.java
@@ -13,9 +13,9 @@ public class ColorUtils {
     public enum Colors {
         AWESOME_BLUE(0x5EA5FF),
         PURPLE(0xA672EF),
-        BLUE(0x00F0FF),
+        FIGURA_BLUE(0x00F0FF),
         SOFT_BLUE(0x99BBEE),
-        RED(0xFF2400),
+        FIGURA_RED(0xFF2400),
         ORANGE(0xFFC400),
 
         CHEESE(0xF8C53A),


### PR DESCRIPTION
Renames the colors `RED` and `BLUE` to `FIGURA_RED` and `FIGURA_BLUE`. Fixes [a bug](https://discord.com/channels/1129805506354085959/1312362743827009667) reported by @TotalTakeover where vanilla colors would be inaccesible due to Figura colors taking priority.

---

*Please rebase when merging.*
