### PR TITLE
Update CI to v4, Do not persist credentials

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Validate Gradle wrapper
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 21
@@ -27,13 +27,13 @@ jobs:
         run: ./gradlew build
 
       - name: Upload Fabric artifacts to GitHub
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Fabric-Artifacts
           path: fabric/build/libs/
 
       - name: Upload Forge artifacts to GitHub
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Forge-Artifacts
           path: forge/build/libs/

--- a/.github/workflows/update-base.yml
+++ b/.github/workflows/update-base.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event.commits.size }}
+          persist-credentials: false
 
       - name: Find Modifying Commit
         run: |


### PR DESCRIPTION
Mainly to comply with [GitHub's breaking changes blog](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions) and also because `zizmor` spotted credentials being persistent which is unsafe, Ubuntu release on other hand can stay frozen mainly due to stability reasons.