### PR TITLE
Update PlayerRendererMixin.java

### DIFF
--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/PlayerRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/PlayerRendererMixin.java
@@ -112,7 +112,9 @@ public abstract class PlayerRendererMixin extends LivingEntityRenderer<AbstractC
 
         // badges
         FiguraMod.popPushProfiler("badges");
-        replacement = Badges.appendBadges(replacement, Minecraft.getInstance().level.getEntity(player.id).getUUID(), config > 1);
+        if (Minecraft.getInstance().level.getEntity(player.id) != null) { // null while dead
+			replacement = Badges.appendBadges(replacement, Minecraft.getInstance().level.getEntity(player.id).getUUID(), config > 1);
+		}
 
         FiguraMod.popPushProfiler("applyName");
         text = TextUtils.replaceInText(text, "\\b" + Pattern.quote(player.name) + "\\b", replacement);


### PR DESCRIPTION
Fix the player nameplate being changed while dead causing a crash due to return value of getEntity being null