### PR TITLE
Add arrow hiding function

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/RendererAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/RendererAPI.java
@@ -62,6 +62,7 @@ public class RendererAPI {
     public FiguraVec4 blockOutlineColor;
     public Boolean upsideDown;
     public Boolean rootRotation;
+    public Boolean renderArrows;
 
     public RendererAPI(Avatar owner) {
         this.owner = owner.owner;
@@ -438,6 +439,22 @@ public class RendererAPI {
     public RendererAPI postEffect(String effect) {
         return setPostEffect(effect);
     }
+
+    @LuaWhitelist
+    @LuaMethodDoc(
+            overloads = @LuaMethodOverload(
+                    argumentTypes = Boolean.class,
+                    argumentNames = "bool"
+            ),
+            aliases = "renderArrows",
+            value = "renderer.set_render_arrows"
+    )
+    public RendererAPI setRenderArrows(Boolean bool) {
+        this.renderArrows = bool;
+        return this;
+    }
+    @LuaWhitelist
+    public RendererAPI renderArrows(Boolean bool) { return setRenderArrows(bool); }
 
     @LuaWhitelist
     @LuaMethodDoc("renderer.get_fov")

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/StuckArrowsFeatureRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/StuckArrowsFeatureRendererMixin.java
@@ -1,0 +1,27 @@
+package org.figuramc.figura.mixin.render.renderers;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.layers.ArrowLayer;
+import net.minecraft.world.entity.Entity;
+import org.figuramc.figura.FiguraMod;
+import org.figuramc.figura.avatar.Avatar;
+import org.figuramc.figura.avatar.AvatarManager;
+import org.figuramc.figura.permissions.Permissions;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ArrowLayer.class)
+public abstract class StuckArrowsFeatureRendererMixin {
+	private static boolean bool = true;
+
+	@Inject(method = "renderStuckItem", at = @At("HEAD"), cancellable = true)
+	private void disableStuckArrowsRendering(PoseStack matrices, MultiBufferSource vertexConsumers, int light, Entity entity, float directionX, float directionY, float directionZ, float tickDelta, CallbackInfo ci) {
+	Avatar avatar = AvatarManager.getAvatarForPlayer(FiguraMod.getLocalPlayerUUID());
+		if (avatar != null && avatar.luaRuntime != null && avatar.luaRuntime.renderer.renderArrows != null && !avatar.luaRuntime.renderer.renderArrows && avatar.permissions.get(Permissions.VANILLA_MODEL_EDIT) == 1) {
+			ci.cancel();
+		}
+	}
+}

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/StuckArrowsFeatureRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/StuckArrowsFeatureRendererMixin.java
@@ -15,13 +15,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ArrowLayer.class)
 public abstract class StuckArrowsFeatureRendererMixin {
-	private static boolean bool = true;
-
 	@Inject(method = "renderStuckItem", at = @At("HEAD"), cancellable = true)
 	private void disableStuckArrowsRendering(PoseStack matrices, MultiBufferSource vertexConsumers, int light, Entity entity, float directionX, float directionY, float directionZ, float tickDelta, CallbackInfo ci) {
-	Avatar avatar = AvatarManager.getAvatarForPlayer(FiguraMod.getLocalPlayerUUID());
-		if (avatar != null && avatar.luaRuntime != null && avatar.luaRuntime.renderer.renderArrows != null && !avatar.luaRuntime.renderer.renderArrows && avatar.permissions.get(Permissions.VANILLA_MODEL_EDIT) == 1) {
-			ci.cancel();
+		Avatar avatar = AvatarManager.getAvatar(entity);
+		if (avatar != null && avatar.luaRuntime != null
+			&& avatar.luaRuntime.renderer.renderArrows != null
+			&& !avatar.luaRuntime.renderer.renderArrows
+			&& avatar.permissions.get(Permissions.VANILLA_MODEL_EDIT) == 1) {
+				ci.cancel();
 		}
 	}
 }

--- a/common/src/main/resources/assets/figura/lang/en_us.json
+++ b/common/src/main/resources/assets/figura/lang/en_us.json
@@ -1468,6 +1468,7 @@
     "figura.docs.renderer.get_camera_normal": "Returns the modified camera normal matrix",
     "figura.docs.renderer.set_camera_normal": "Sets the camera normal matrix with the given matrix",
     "figura.docs.renderer.set_post_effect": "Sets the current rendering effect\nSame as the discontinued Super Secret Settings",
+    "figura.docs.renderer.set_render_arrows": "Sets whether or not arrows should be rendered",
     "figura.docs.renderer.get_fov": "Gets the multiplier of your fov",
     "figura.docs.renderer.set_fov": "Sets the multiplier of your fov\nThe default value is nil, which means no changes will be applied to your fov",
     "figura.docs.renderer.get_crosshair_offset": "Gets the offset of your crosshair",

--- a/common/src/main/resources/figura-common.mixins.json
+++ b/common/src/main/resources/figura-common.mixins.json
@@ -88,6 +88,7 @@
     "render.renderers.ScreenEffectRendererMixin",
     "render.renderers.SignRendererMixin",
     "render.renderers.SkullBlockRendererMixin",
+    "render.renderers.StuckArrowsFeatureRendererMixin",
     "render.renderers.TridentRendererMixin",
     "render.PoseStackAccessor",
     "sound.ChannelHandleMixin",


### PR DESCRIPTION
Adds a function to `RendererAPI`, `setRenderArrows`, to control whether or not arrows stuck in the player are rendered. Adds an entry in `en_us.json` for it and adds a mixin for it.