### PR TITLE
Removed https:// prefix from example networkingAPI filter item

### DIFF
--- a/common/src/main/java/org/figuramc/figura/gui/widgets/lists/NetworkFilterList.java
+++ b/common/src/main/java/org/figuramc/figura/gui/widgets/lists/NetworkFilterList.java
@@ -188,7 +188,7 @@ public class NetworkFilterList extends AbstractList {
         private final TextField filterTextField;
         private final NetworkFilterList parent;
         public NetworkFilterEntry(NetworkFilterList parent, int x, int y, int width, int height) {
-            this(parent, x, y, width, height, new NetworkingAPI.Filter("https://example.com"));
+            this(parent, x, y, width, height, new NetworkingAPI.Filter("example.com"));
         }
 
         public NetworkFilterEntry(NetworkFilterList parent, int x, int y, int width, int height, NetworkingAPI.Filter sourceFilter) {


### PR DESCRIPTION
So basically when creating a new entry in this goofy menu it has the protocol right
![image](https://github.com/user-attachments/assets/2ac85bbe-1b80-4311-94e8-db140dcddcc8)
Well if you actually try running a network request with it, it fails
![image](https://github.com/user-attachments/assets/9613074a-1b04-4372-b071-25190150e079)
Removing it in the filter makes it work soooo

Anyways I just made this because it caused endless suffering that I would not wish upon my worst enemy and it'd be better if the example actually worked :sob:

Or just change other stuff to make the example work idk

Most influential change