### PR TITLE
Add "/figura upload" command

### DIFF
--- a/common/src/main/java/org/figuramc/figura/commands/FiguraCommands.java
+++ b/common/src/main/java/org/figuramc/figura/commands/FiguraCommands.java
@@ -31,6 +31,9 @@ public class FiguraCommands {
         // load
         root.then(LoadCommand.getCommand());
 
+        // upload
+        root.then(UploadCommand.getCommand());
+
         // reload
         root.then(ReloadCommand.getCommand());
 

--- a/common/src/main/java/org/figuramc/figura/commands/UploadCommand.java
+++ b/common/src/main/java/org/figuramc/figura/commands/UploadCommand.java
@@ -1,0 +1,24 @@
+package org.figuramc.figura.commands;
+
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+
+import org.figuramc.figura.FiguraMod;
+import org.figuramc.figura.avatar.Avatar;
+import org.figuramc.figura.avatar.AvatarManager;
+import org.figuramc.figura.backend2.NetworkStuff;
+import org.figuramc.figura.gui.widgets.lists.AvatarList;
+import org.figuramc.figura.utils.FiguraClientCommandSource;
+
+class UploadCommand {
+    public static LiteralArgumentBuilder<FiguraClientCommandSource> getCommand() {
+        LiteralArgumentBuilder<FiguraClientCommandSource> upload = LiteralArgumentBuilder.literal("upload");
+        upload.executes(context -> {
+            Avatar avatar = AvatarManager.getAvatarForPlayer(FiguraMod.getLocalPlayerUUID());
+
+            NetworkStuff.uploadAvatar(avatar);
+            AvatarList.selectedEntry = null;
+            return 1;
+        });
+        return upload;
+    }
+}

--- a/common/src/main/java/org/figuramc/figura/lua/api/net/NetworkingAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/net/NetworkingAPI.java
@@ -89,9 +89,9 @@ public class NetworkingAPI {
         if (level == null) return false;
         ArrayList<Filter> filters = Configs.NETWORK_FILTER.getFilters();
         try {
-            URL url = new URL(link);
-            if (url.getPort() != -1 && url.getPort() != 80 && url.getPort() != 443)
-                throw new LuaError("Port %s not allowed, only 80 (HTTP) and 443 (HTTPS) are permitted.".formatted(url.getPort()));
+            // URL url = new URL(link);
+            // if (url.getPort() != -1 && url.getPort() != 80 && url.getPort() != 443)
+            //     throw new LuaError("Port %s not allowed, only 80 (HTTP) and 443 (HTTPS) are permitted.".formatted(url.getPort()));
 
             return switch (level) {
                 case WHITELIST -> filters.stream().anyMatch(f -> f.matches(url.getHost()));

--- a/common/src/main/java/org/figuramc/figura/lua/api/net/NetworkingAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/net/NetworkingAPI.java
@@ -89,9 +89,7 @@ public class NetworkingAPI {
         if (level == null) return false;
         ArrayList<Filter> filters = Configs.NETWORK_FILTER.getFilters();
         try {
-            // URL url = new URL(link);
-            // if (url.getPort() != -1 && url.getPort() != 80 && url.getPort() != 443)
-            //     throw new LuaError("Port %s not allowed, only 80 (HTTP) and 443 (HTTPS) are permitted.".formatted(url.getPort()));
+            URL url = new URL(link);
 
             return switch (level) {
                 case WHITELIST -> filters.stream().anyMatch(f -> f.matches(url.getHost()));


### PR DESCRIPTION
Adds an upload command that well... uploads the currently selected avatar.
You can select this avatar with /figura load or simply click it in the wardrobe.

(cherry picked from #270)

---

Kept the commits that removed the port restriction (which feels unnecessary anyway, IMO) since it was a part of the original PR, but let me know if I should separate it.