### PR TITLE
Add getCameraMatrix method to ClientAPI

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/ClientAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/ClientAPI.java
@@ -3,6 +3,7 @@ package org.figuramc.figura.lua.api;
 import com.google.common.base.Suppliers;
 import com.mojang.blaze3d.platform.Window;
 import net.minecraft.SharedConstants;
+import net.minecraft.client.Camera;
 import net.minecraft.client.ClientBrandRetriever;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.MouseHandler;
@@ -31,12 +32,14 @@ import org.figuramc.figura.lua.docs.FiguraListDocs;
 import org.figuramc.figura.lua.docs.LuaMethodDoc;
 import org.figuramc.figura.lua.docs.LuaMethodOverload;
 import org.figuramc.figura.lua.docs.LuaTypeDoc;
+import org.figuramc.figura.math.matrix.FiguraMat4;
 import org.figuramc.figura.math.vector.FiguraVec2;
 import org.figuramc.figura.math.vector.FiguraVec3;
 import org.figuramc.figura.mixin.gui.GuiAccessor;
 import org.figuramc.figura.mixin.gui.PlayerTabOverlayAccessor;
 import org.figuramc.figura.mixin.render.ModelManagerAccessor;
 import org.figuramc.figura.utils.*;
+import org.joml.Matrix4f;
 import org.joml.Vector3f;
 import org.luaj.vm2.LuaError;
 import org.luaj.vm2.LuaValue;
@@ -275,6 +278,24 @@ public class ClientAPI {
         quaternion.getEulerAnglesYXZ(vec);
         double f = 180d / Math.PI;
         return FiguraVec3.fromVec3f(vec).multiply(f, -f, f); // degrees, and negate y
+    }
+
+    @LuaWhitelist
+    @LuaMethodDoc("client.get_camera_matrix")
+    public static FiguraMat4 getCameraMatrix() {
+        Camera camera = Minecraft.getInstance().gameRenderer.getMainCamera();
+        Vec3 cameraPos = camera.getPosition();
+        Matrix4f viewMatrix = new Matrix4f()
+                .rotate(
+                        camera.rotation()
+                )
+                .translate(
+                        (float) -cameraPos.x,
+                        (float) -cameraPos.y,
+                        (float) -cameraPos.z
+                );
+
+        return new FiguraMat4().set(viewMatrix);
     }
 
     @LuaWhitelist

--- a/common/src/main/resources/assets/figura/lang/en_us.json
+++ b/common/src/main/resources/assets/figura/lang/en_us.json
@@ -914,6 +914,7 @@
     "figura.docs.client.get_gui_scale": "Returns the current value of your Gui Scale setting\nIf you use auto, then it gets the actual current scale",
     "figura.docs.client.get_camera_pos": "Returns the position of the viewer's camera",
     "figura.docs.client.get_camera_rot": "Returns the rotation of the viewer's camera",
+    "figura.docs.client.get_camera_matrix": "Returns the transformation matrix of the viewer's camera",
     "figura.docs.client.get_camera_dir": "Returns a unit vector pointing in the direction that the camera is facing",
     "figura.docs.client.get_text_width": "Returns the width of the given text in pixels\nIn case of multiple lines, return the largest width of all lines",
     "figura.docs.client.get_text_height": "Returns the height of the given text in pixels",


### PR DESCRIPTION
Requested by GNamimates, saves a bunch of unnecessary calculation