### PR TITLE
feat: add HostAPI function to get held item in cursor

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/HostAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/HostAPI.java
@@ -90,6 +90,14 @@ public class HostAPI {
         return this;
     }
 
+    @LuaMethodDoc("host.get_cursor_item")
+    @LuaWhitelist
+    public ItemStackAPI getCursorItem() {
+        if (!isHost() || this.minecraft.player == null)
+            return ItemStackAPI.verify(ItemStack.EMPTY);
+        return ItemStackAPI.verify(this.minecraft.player.containerMenu.getCarried());
+    }
+
     @LuaWhitelist
     @LuaMethodDoc(
             overloads = {

--- a/common/src/main/resources/assets/figura/lang/en_us.json
+++ b/common/src/main/resources/assets/figura/lang/en_us.json
@@ -1098,7 +1098,7 @@
     "figura.docs.host.set_chat_color": "Sets the color of the text that is currently being typed into the chat window",
     "figura.docs.host.get_chat_text": "Gets the text that is currently being typed into the chat window",
     "figura.docs.host.set_chat_text": "Sets the text currently being typed in the chat window to the given string",
-    "figura.docs.host.get_cursor_item": "Gets the item currently held by the cursor, or air if none is held.",
+    "figura.docs.host.get_cursor_item": "Gets the item currently held by the cursor, or air if none is held",
     "figura.docs.host.get_screen": "Gets the class name of the screen the player is currently on\nIf the player is not currently in a screen, returns nil",
     "figura.docs.host.get_screen_slot_count": "Gets the number of slots in the screen the player is currently in\nIf the player is not currently in a screen or the screen has no slots, returns nil",
     "figura.docs.host.get_screen_slot": "Gets the item in a screen slot\nThe slot is either their numerical id (0 indexed) or the slot string, as used in the /item command\nIf the player is not currently in a screen, the screen has no slots, or the slot index is greater than the maximum, returns nil",

--- a/common/src/main/resources/assets/figura/lang/en_us.json
+++ b/common/src/main/resources/assets/figura/lang/en_us.json
@@ -1098,6 +1098,7 @@
     "figura.docs.host.set_chat_color": "Sets the color of the text that is currently being typed into the chat window",
     "figura.docs.host.get_chat_text": "Gets the text that is currently being typed into the chat window",
     "figura.docs.host.set_chat_text": "Sets the text currently being typed in the chat window to the given string",
+    "figura.docs.host.get_cursor_item": "Gets the item currently held by the cursor, or air if none is held.",
     "figura.docs.host.get_screen": "Gets the class name of the screen the player is currently on\nIf the player is not currently in a screen, returns nil",
     "figura.docs.host.get_screen_slot_count": "Gets the number of slots in the screen the player is currently in\nIf the player is not currently in a screen or the screen has no slots, returns nil",
     "figura.docs.host.get_screen_slot": "Gets the item in a screen slot\nThe slot is either their numerical id (0 indexed) or the slot string, as used in the /item command\nIf the player is not currently in a screen, the screen has no slots, or the slot index is greater than the maximum, returns nil",


### PR DESCRIPTION
Adds `host:getCursorItem()` and creates the relevant en_us.json entry