### PR TITLE
fix: bump fabric loader to version 0.15.10 on 1.20

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ brigadier = 1.0.18
 # https://fabricmc.net/develop
 # https://modrinth.com/mod/fabric-api
 fabric_api = 0.86.1+1.20.1
-fabric_loader_version = 0.14.25
+fabric_loader_version = 0.15.10
 
 # Mod Dependencies
 # https://modrinth.com/mod/modmenu


### PR DESCRIPTION
Required by `me.lucko:fabric-permissions-api`, brought in by the FSB merge.
If I don't do this, `:fabric:runClient` doesn't work due to a weird conflict between Mixin and Fabric and I can't test anything.
also the end user would have to have at least this version of Fabric anyway or else the dependencies wouldnt work (probably)

```
modImplementation
+--- me.lucko:fabric-permissions-api:0.3.1
|    +--- net.fabricmc:fabric-loader:0.15.10 <-- this causes Gradle to bump the version used in the entire build
|    \--- net.fabricmc.fabric-api:fabric-api-base:0.4.37+78d798af4f
+--- net.fabricmc:fabric-loader:0.14.25 -> 0.15.10
+--- net.fabricmc.fabric-api:fabric-api-base:0.4.30+7abfd51577 -> 0.4.37+78d798af4f
+--- net.fabricmc.fabric-api:fabric-command-api-v2:2.2.12+b3afc78b77
|    \--- net.fabricmc.fabric-api:fabric-api-base:0.4.30+7abfd51577 -> 0.4.37+78d798af4f
+--- net.fabricmc.fabric-api:fabric-key-binding-api-v1:1.0.36+fb8d95da77
+--- net.fabricmc.fabric-api:fabric-resource-loader-v0:0.11.9+132c48c177
\--- net.fabricmc.fabric-api:fabric-networking-api-v1:1.3.9+b3afc78b77
     \--- net.fabricmc.fabric-api:fabric-api-base:0.4.30+7abfd51577 -> 0.4.37+78d798af4f
```