### PR TITLE
Nameplate unload crash fix (1.21.3 edition)

### DIFF
--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/PlayerRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/PlayerRendererMixin.java
@@ -112,7 +112,9 @@ public abstract class PlayerRendererMixin extends LivingEntityRenderer<AbstractC
 
         // badges
         FiguraMod.popPushProfiler("badges");
-        replacement = Badges.appendBadges(replacement, Minecraft.getInstance().level.getEntity(player.id).getUUID(), config > 1);
+        if (Minecraft.getInstance().level.getEntity(player.id) != null) { // null while dead
+			replacement = Badges.appendBadges(replacement, Minecraft.getInstance().level.getEntity(player.id).getUUID(), config > 1);
+		}
 
         FiguraMod.popPushProfiler("applyName");
         text = TextUtils.replaceInText(text, "\\b" + Pattern.quote(player.name) + "\\b", replacement);

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/PlayerRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/PlayerRendererMixin.java
@@ -113,8 +113,8 @@ public abstract class PlayerRendererMixin extends LivingEntityRenderer<AbstractC
         // badges
         FiguraMod.popPushProfiler("badges");
         if (Minecraft.getInstance().level.getEntity(player.id) != null) { // null while dead
-			replacement = Badges.appendBadges(replacement, Minecraft.getInstance().level.getEntity(player.id).getUUID(), config > 1);
-		}
+		replacement = Badges.appendBadges(replacement, Minecraft.getInstance().level.getEntity(player.id).getUUID(), config > 1);
+        }
 
         FiguraMod.popPushProfiler("applyName");
         text = TextUtils.replaceInText(text, "\\b" + Pattern.quote(player.name) + "\\b", replacement);


### PR DESCRIPTION
Fix the player nameplate being changed while dead causing a crash due to return value of getEntity being null

so it turns out the changes were actually on the 1.21.3 version and they were just... missing? this is already on 1.21.4 from #290 