### PR TITLE
Fix Sodium compatibility by renaming conflicting TextureAtlas accessors

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/TextureAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/TextureAPI.java
@@ -63,7 +63,8 @@ public class TextureAPI {
                     argumentTypes = {String.class, Integer.class, Integer.class},
                     argumentNames = {"name", "width", "height"}
             ),
-            value = "textures.new_texture")
+            value = "textures.new_texture"
+    )
     public FiguraTexture newTexture(@LuaNotNil String name, int width, int height) {
         NativeImage image;
         try {
@@ -89,7 +90,8 @@ public class TextureAPI {
                             argumentNames = {"name", "byteArray"}
                     )
             },
-            value = "textures.read")
+            value = "textures.read"
+    )
     public FiguraTexture read(@LuaNotNil String name, @LuaNotNil Object object) {
         NativeImage image;
         byte[] bytes;
@@ -121,7 +123,8 @@ public class TextureAPI {
                     argumentTypes = {String.class, FiguraTexture.class},
                     argumentNames = {"name", "texture"}
             ),
-            value = "textures.copy")
+            value = "textures.copy"
+    )
     public FiguraTexture copy(@LuaNotNil String name, @LuaNotNil FiguraTexture texture) {
         NativeImage image = texture.copy();
         return register(name, image, false);
@@ -133,7 +136,8 @@ public class TextureAPI {
                     argumentTypes = String.class,
                     argumentNames = "name"
             ),
-            value = "textures.get")
+            value = "textures.get"
+    )
     public FiguraTexture get(@LuaNotNil String name) {
         check();
         return owner.renderer.customTextures.get(name);
@@ -162,9 +166,9 @@ public class TextureAPI {
             TextureAtlas atlas = Minecraft.getInstance().getModelManager().getAtlas(resourceLocation);
             GpuTexture atlasGpuTexture = atlas.getTexture();
             TextureAtlasAccessor atlasAccessor = (TextureAtlasAccessor) atlas;
-            NativeImage nativeImage = new NativeImage(atlasAccessor.getWidth(), atlasAccessor.getHeight(), false);
-            int width = atlasAccessor.getWidth();
-            int height = atlasAccessor.getHeight();
+            NativeImage nativeImage = new NativeImage(atlasAccessor.figuraGetWidth(), atlasAccessor.figuraGetHeight(), false);
+            int width = atlasAccessor.figuraGetWidth();
+            int height = atlasAccessor.figuraGetHeight();
 
             CommandEncoder encoder = RenderSystem.getDevice().createCommandEncoder();
             GpuBuffer gpuBuffer = RenderSystem.getDevice().createBuffer(() -> "Atlas Read Buffer", BufferType.PIXEL_PACK, BufferUsage.STATIC_READ, width * height * atlasGpuTexture.getFormat().pixelSize());

--- a/common/src/main/java/org/figuramc/figura/lua/api/TextureAtlasAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/TextureAtlasAPI.java
@@ -54,13 +54,13 @@ public class TextureAtlasAPI {
     @LuaWhitelist
     @LuaMethodDoc("texture_atlas.get_width")
     public int getWidth() {
-        return ((TextureAtlasAccessor) atlas).getWidth();
+        return ((TextureAtlasAccessor) atlas).figuraGetWidth();
     }
 
     @LuaWhitelist
     @LuaMethodDoc("texture_atlas.get_height")
     public int getHeight() {
-        return ((TextureAtlasAccessor) atlas).getHeight();
+        return ((TextureAtlasAccessor) atlas).figuraGetHeight();
     }
 
     @Override

--- a/common/src/main/java/org/figuramc/figura/mixin/render/TextureAtlasAccessor.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/TextureAtlasAccessor.java
@@ -16,11 +16,13 @@ public interface TextureAtlasAccessor {
     @Accessor("texturesByName")
     Map<ResourceLocation, TextureAtlasSprite> getTexturesByName();
 
+    // Renamed from getWidth() to figuraGetWidth() to avoid conflict with Sodium
     @Intrinsic
     @Invoker("getWidth")
-    int getWidth();
+    int figuraGetWidth();
 
+    // Renamed from getHeight() to figuraGetHeight() to avoid conflict with Sodium
     @Intrinsic
     @Invoker("getHeight")
-    int getHeight();
+    int figuraGetHeight();
 }

--- a/common/src/main/java/org/figuramc/figura/model/TextureCustomization.java
+++ b/common/src/main/java/org/figuramc/figura/model/TextureCustomization.java
@@ -58,9 +58,9 @@ public class TextureCustomization {
             TextureAtlas atlas = Minecraft.getInstance().getModelManager().getAtlas(resourceLocation);
             GpuTexture atlasGpuTexture = atlas.getTexture();
             TextureAtlasAccessor atlasAccessor = (TextureAtlasAccessor) atlas;
-            NativeImage nativeImage = new NativeImage(atlasAccessor.getWidth(), atlasAccessor.getHeight(), false);
-            int width = atlasAccessor.getWidth();
-            int height = atlasAccessor.getHeight();
+            NativeImage nativeImage = new NativeImage(atlasAccessor.figuraGetWidth(), atlasAccessor.figuraGetHeight(), false);
+            int width = atlasAccessor.figuraGetWidth();
+            int height = atlasAccessor.figuraGetHeight();
 
             CommandEncoder encoder = RenderSystem.getDevice().createCommandEncoder();
             GpuBuffer gpuBuffer = RenderSystem.getDevice().createBuffer(() -> "Atlas Read Buffer", BufferType.PIXEL_PACK, BufferUsage.STATIC_READ, width * height * atlasGpuTexture.getFormat().pixelSize());


### PR DESCRIPTION
# Fix Sodium Compatibility Issue

When using Figura alongside Sodium, the game crashes on startup due to conflicting mixin accessors. Both mods attempt to access the same TextureAtlas methods (`getWidth()` and `getHeight()`) through incompatible accessor definitions, resulting in:

Incompatible @Accessor getWidth (for field_43113:I) in sodium-common.mixins.json:core.render.texture.TextureAtlasAccessor from mod sodium previously written by org.figuramc.figura.mixin.render.TextureAtlasAccessor

## Changes Made
- Renamed Figura's TextureAtlas accessor methods to avoid conflicts with Sodium:
  - `getWidth()` → `figuraGetWidth()`
  - `getHeight()` → `figuraGetHeight()`
- Updated all references to these methods throughout the codebase:
  - `TextureAtlasAPI.java`
  - `TextureCustomization.java`
  - `TextureAPI.java`

## Testing
Tested with Minecraft 1.21.5, Fabric Loader 0.16.12, and Sodium 0.6.12+mc1.21.5. The game now launches and runs normally with both mods installed.
