### PR TITLE
FSB: fix crashes, and a few UX things

### DIFF
--- a/common/src/main/java/org/figuramc/figura/backend2/FSB.java
+++ b/common/src/main/java/org/figuramc/figura/backend2/FSB.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.Nullable;
 import java.io.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public abstract class FSB {
     private static FSB instance;
@@ -39,6 +40,7 @@ public abstract class FSB {
 
     private final HashSet<UUID> connectedPlayers = new HashSet<>();
     private final ConcurrentLinkedDeque<S2CAvatarReadyPacket> uploadCompletedAvatars = new ConcurrentLinkedDeque<>();
+    private final AtomicBoolean hasDeletedAvatar = new AtomicBoolean(false);
 
     private int handshakeTick = 0;
     private int handshakeAttempts = 0;
@@ -180,6 +182,14 @@ public abstract class FSB {
 
     public @Nullable S2CAvatarReadyPacket nextReadyAvatar() {
         return uploadCompletedAvatars.poll();
+    }
+
+    public void handleAvatarDeleted() {
+        hasDeletedAvatar.set(true);
+    }
+
+    public boolean pollAvatarDeleted() {
+        return hasDeletedAvatar.getAndSet(false);
     }
 
     public void reset(UUID id) {

--- a/common/src/main/java/org/figuramc/figura/backend2/FSB.java
+++ b/common/src/main/java/org/figuramc/figura/backend2/FSB.java
@@ -21,9 +21,11 @@ import com.mojang.datafixers.util.Pair;
 import org.figuramc.figura.server.utils.StatusCode;
 import org.figuramc.figura.server.utils.Utils;
 import org.figuramc.figura.utils.FiguraText;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
 import java.util.*;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 public abstract class FSB {
     private static FSB instance;
@@ -36,6 +38,7 @@ public abstract class FSB {
     private final HashMap<Integer, AvatarInputStream> inputStreams = new HashMap<>();
 
     private final HashSet<UUID> connectedPlayers = new HashSet<>();
+    private final ConcurrentLinkedDeque<S2CAvatarReadyPacket> uploadCompletedAvatars = new ConcurrentLinkedDeque<>();
 
     private int handshakeTick = 0;
     private int handshakeAttempts = 0;
@@ -169,6 +172,14 @@ public abstract class FSB {
     public void handleUserConnected(S2CConnectedPacket packet) {
         connectedPlayers.add(packet.player());
         AvatarManager.clearAvatars(packet.player());
+    }
+
+    public void handleAvatarReady(S2CAvatarReadyPacket packet) {
+        uploadCompletedAvatars.add(packet);
+    }
+
+    public @Nullable S2CAvatarReadyPacket nextReadyAvatar() {
+        return uploadCompletedAvatars.poll();
     }
 
     public void reset(UUID id) {
@@ -371,9 +382,7 @@ public abstract class FSB {
         private void close(StatusCode code) {
             switch (code) {
                 case FINISHED, ALREADY_EXISTS -> {
-                    FiguraToast.sendToast(FiguraText.of("backend.upload_success"));
-                    parent.equipAvatar(List.of(Pair.of(avatarId, Utils.getHash(data))));
-                    AvatarManager.localUploaded = true;
+                    // This is handled by the AvatarReadyPacket.
                 }
                 case MAX_AVATAR_SIZE_EXCEEDED -> {
                     FiguraToast.sendToast(FiguraText.of("backend.upload_too_big"), FiguraToast.ToastType.ERROR);

--- a/common/src/main/java/org/figuramc/figura/backend2/NetworkStuff.java
+++ b/common/src/main/java/org/figuramc/figura/backend2/NetworkStuff.java
@@ -21,9 +21,10 @@ import org.figuramc.figura.backend2.websocket.C2SMessageHandler;
 import org.figuramc.figura.config.Configs;
 import org.figuramc.figura.font.Emojis;
 import org.figuramc.figura.gui.FiguraToast;
-import org.figuramc.figura.permissions.PermissionManager;
-import org.figuramc.figura.permissions.Permissions;
+import org.figuramc.figura.server.avatars.EHashPair;
 import org.figuramc.figura.server.packets.c2s.C2SPingPacket;
+import org.figuramc.figura.server.packets.s2c.S2CAvatarReadyPacket;
+import org.figuramc.figura.server.utils.Hash;
 import org.figuramc.figura.utils.FiguraText;
 import org.figuramc.figura.utils.RefilledNumber;
 import org.figuramc.figura.utils.TextUtils;
@@ -37,10 +38,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.ByteBuffer;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.BitSet;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.BiConsumer;
@@ -106,6 +104,15 @@ public class NetworkStuff {
         //process requests
         if (isConnected())
             processRequests();
+
+        // process FSB uploaded avatars
+        FSB fsb = fsb();
+        if (fsb.connected()) {
+            S2CAvatarReadyPacket h;
+            while ((h = fsb.nextReadyAvatar()) != null) {
+                fsbAvatarUploadCompleted(h.avatarId, h.ref);
+            }
+        }
 
         //pings counter
         if (lastPing > 0 && FiguraMod.ticks - lastPing >= 20)
@@ -370,6 +377,20 @@ public class NetworkStuff {
         });
     }
 
+    protected static Set<Hash> hashesAwaitingUpload = new HashSet<>();
+
+    public static void fsbAvatarUploadCompleted(String avatarId, EHashPair target) {
+        // something about a server->client attack vector?
+        if (!hashesAwaitingUpload.contains(target.hash())) return;
+        hashesAwaitingUpload.remove(target.hash());
+        FSB fsb = fsb();
+        if (fsb.connected()) {
+            FiguraToast.sendToast(FiguraText.of("backend.upload_success"));
+            fsb.equipAvatar(List.of(Pair.of(avatarId, target.hash())));
+            AvatarManager.localUploaded = true;
+        }
+    }
+
     // TODO: multiple modes of upload (Backend, FSB, Backend + FSB)
     public static void uploadAvatar(Avatar avatar, Destination destination) {
         if (avatar == null || avatar.nbt == null)
@@ -385,6 +406,7 @@ public class NetworkStuff {
 
             if (destination.allowFSB()) {
                 fsb().uploadAvatar(id, baos.toByteArray());
+                hashesAwaitingUpload.add(getHash(baos.toByteArray()));
             }
 
             if (destination.allowBackend()) {
@@ -393,9 +415,11 @@ public class NetworkStuff {
 
                     if (code == 200) {
                         //TODO - profile screen
-                        if (fsb().connected()) fsb().equipAvatar(List.of(Pair.of(id, getHash(baos.toByteArray()))));
-                        else equipAvatar(List.of(Pair.of(avatar.owner, id)));
-                        AvatarManager.localUploaded = true;
+                        if (!destination.allowFSB()) {
+                            // use uploaded main backend only if not also uploading to FSB
+                            equipAvatar(List.of(Pair.of(avatar.owner, id)));
+                            AvatarManager.localUploaded = true;
+                        }
                     }
 
                     //feedback

--- a/common/src/main/java/org/figuramc/figura/backend2/NetworkStuff.java
+++ b/common/src/main/java/org/figuramc/figura/backend2/NetworkStuff.java
@@ -112,6 +112,9 @@ public class NetworkStuff {
             while ((h = fsb.nextReadyAvatar()) != null) {
                 fsbAvatarUploadCompleted(h.avatarId, h.ref);
             }
+            if (fsb.pollAvatarDeleted()) {
+                fsbDeleteAvatarCompleted();
+            }
         }
 
         //pings counter
@@ -440,6 +443,10 @@ public class NetworkStuff {
 
     public static void uploadAvatar(Avatar avatar) {
         uploadAvatar(avatar, Destination.FSB_OR_BACKEND);
+    }
+
+    public static void fsbDeleteAvatarCompleted() {
+        FiguraToast.sendToast(FiguraText.of("backend.delete_success"));
     }
 
     public static void deleteAvatar(String avatar, Destination destination) {

--- a/common/src/main/java/org/figuramc/figura/server/packets/handlers/s2c/Handlers.java
+++ b/common/src/main/java/org/figuramc/figura/server/packets/handlers/s2c/Handlers.java
@@ -16,6 +16,7 @@ public class Handlers {
         put(S2CConnectedPacket.PACKET_ID, new S2CConnectedHandler());
         put(S2CUserdataNotFoundPacket.PACKET_ID, new S2CUserdataNotFoundHandler());
         put(AvatarDataPacket.PACKET_ID, new S2CAvatarDataPacketHandler());
+        put(S2CAvatarReadyPacket.PACKET_ID, new S2CAvatarReadyPacketHandler());
         put(CloseIncomingStreamPacket.PACKET_ID, new CloseIncomingStreamPacketHandler());
         put(CloseOutcomingStreamPacket.PACKET_ID, new CloseOutcomingStreamPacketHandler());
         put(AllowIncomingStreamPacket.PACKET_ID, new AllowOutcomingStreamPacketHandler());

--- a/common/src/main/java/org/figuramc/figura/server/packets/handlers/s2c/Handlers.java
+++ b/common/src/main/java/org/figuramc/figura/server/packets/handlers/s2c/Handlers.java
@@ -17,6 +17,7 @@ public class Handlers {
         put(S2CUserdataNotFoundPacket.PACKET_ID, new S2CUserdataNotFoundHandler());
         put(AvatarDataPacket.PACKET_ID, new S2CAvatarDataPacketHandler());
         put(S2CAvatarReadyPacket.PACKET_ID, new S2CAvatarReadyPacketHandler());
+        put(S2CAvatarDeletedPacket.PACKET_ID, new S2CAvatarDeletedPacketHandler());
         put(CloseIncomingStreamPacket.PACKET_ID, new CloseIncomingStreamPacketHandler());
         put(CloseOutcomingStreamPacket.PACKET_ID, new CloseOutcomingStreamPacketHandler());
         put(AllowIncomingStreamPacket.PACKET_ID, new AllowOutcomingStreamPacketHandler());

--- a/common/src/main/java/org/figuramc/figura/server/packets/handlers/s2c/S2CAvatarDeletedPacketHandler.java
+++ b/common/src/main/java/org/figuramc/figura/server/packets/handlers/s2c/S2CAvatarDeletedPacketHandler.java
@@ -1,0 +1,18 @@
+package org.figuramc.figura.server.packets.handlers.s2c;
+
+import org.figuramc.figura.backend2.FSB;
+import org.figuramc.figura.server.packets.s2c.S2CAvatarDeletedPacket;
+import org.figuramc.figura.server.packets.s2c.S2CAvatarReadyPacket;
+import org.figuramc.figura.server.utils.IFriendlyByteBuf;
+
+public class S2CAvatarDeletedPacketHandler extends ConnectedPacketHandler<S2CAvatarDeletedPacket>  {
+    @Override
+    protected void handlePacket(S2CAvatarDeletedPacket packet) {
+        FSB.instance().handleAvatarDeleted();
+    }
+
+    @Override
+    public S2CAvatarDeletedPacket serialize(IFriendlyByteBuf byteBuf) {
+        return new S2CAvatarDeletedPacket(byteBuf);
+    }
+}

--- a/common/src/main/java/org/figuramc/figura/server/packets/handlers/s2c/S2CAvatarReadyPacketHandler.java
+++ b/common/src/main/java/org/figuramc/figura/server/packets/handlers/s2c/S2CAvatarReadyPacketHandler.java
@@ -1,0 +1,17 @@
+package org.figuramc.figura.server.packets.handlers.s2c;
+
+import org.figuramc.figura.backend2.FSB;
+import org.figuramc.figura.server.packets.s2c.S2CAvatarReadyPacket;
+import org.figuramc.figura.server.utils.IFriendlyByteBuf;
+
+public class S2CAvatarReadyPacketHandler extends ConnectedPacketHandler<S2CAvatarReadyPacket>  {
+    @Override
+    protected void handlePacket(S2CAvatarReadyPacket packet) {
+        FSB.instance().handleAvatarReady(packet);
+    }
+
+    @Override
+    public S2CAvatarReadyPacket serialize(IFriendlyByteBuf byteBuf) {
+        return new S2CAvatarReadyPacket(byteBuf);
+    }
+}

--- a/fabric/src/main/java/org/figuramc/figura/config/fabric/ModMenuConfig.java
+++ b/fabric/src/main/java/org/figuramc/figura/config/fabric/ModMenuConfig.java
@@ -3,7 +3,6 @@ package org.figuramc.figura.config.fabric;
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
 import org.figuramc.figura.FiguraMod;
-import org.figuramc.figura.config.Configs;
 import org.figuramc.figura.gui.screens.ConfigScreen;
 
 public class ModMenuConfig implements ModMenuApi {

--- a/server-common/src/main/java/org/figuramc/figura/server/FiguraUser.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/FiguraUser.java
@@ -159,25 +159,41 @@ public final class FiguraUser {
     public void removeOwnedAvatar(String avatarId) {
         if (ownedAvatars.containsKey(avatarId)) {
             EHashPair avatar = ownedAvatars.remove(avatarId);
-            FiguraServer.getInstance().avatarManager().getAvatarMetadata(avatar.hash()).owners().remove(uuid());
+            try {
+                FiguraServer.getInstance().avatarManager().getAvatarMetadata(avatar.hash()).owners().remove(uuid());
+            } catch (RuntimeException re) {
+                FiguraServer.getInstance().logError("Failed to remove owned avatar", re);
+            }
         }
     }
 
     public void removeEquippedAvatar() {
         if (equippedAvatar != null) {
-            FiguraServer.getInstance().avatarManager().getAvatarMetadata(equippedAvatar.right().hash()).equipped().remove(uuid());
-            equippedAvatar = null;
+            try {
+                FiguraServer.getInstance().avatarManager().getAvatarMetadata(equippedAvatar.right().hash()).equipped().remove(uuid());
+                equippedAvatar = null;
+            } catch (RuntimeException re) {
+                FiguraServer.getInstance().logError("Failed to remove equipped avatar", re);
+            }
         }
     }
 
     public void replaceOrAddOwnedAvatar(String avatarId, Hash hash, Hash ehash) {
-        ownedAvatars.put(avatarId, new EHashPair(hash, ehash));
-        FiguraServer.getInstance().avatarManager().getAvatarMetadata(hash).owners().put(uuid(), ehash);
+        try {
+            FiguraServer.getInstance().avatarManager().getAvatarMetadata(hash).owners().put(uuid(), ehash);
+            ownedAvatars.put(avatarId, new EHashPair(hash, ehash));
+        } catch (RuntimeException re) {
+            FiguraServer.getInstance().logError("Failed to replace/add avatar", re);
+        }
     }
 
     public void setEquippedAvatar(String avatarId, Hash hash, Hash ehash) {
-        equippedAvatar = new Pair<>(avatarId, new EHashPair(hash, ehash));
-        FiguraServer.getInstance().avatarManager().getAvatarMetadata(hash).equipped().put(uuid(), ehash);
+        try {
+            FiguraServer.getInstance().avatarManager().getAvatarMetadata(hash).equipped().put(uuid(), ehash);
+            equippedAvatar = new Pair<>(avatarId, new EHashPair(hash, ehash));
+        } catch (RuntimeException re) {
+            FiguraServer.getInstance().logError("Failed to set equipped avatar", re);
+        }
     }
 
     public int getAvatarsCountWithId(String avatarId) {

--- a/server-common/src/main/java/org/figuramc/figura/server/avatars/FiguraServerAvatarManager.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/avatars/FiguraServerAvatarManager.java
@@ -7,8 +7,10 @@ import org.figuramc.figura.server.events.avatars.*;
 import org.figuramc.figura.server.exceptions.HashNotMatchingException;
 import org.figuramc.figura.server.packets.AvatarDataPacket;
 import org.figuramc.figura.server.packets.CloseIncomingStreamPacket;
+import org.figuramc.figura.server.packets.s2c.S2CAvatarReadyPacket;
 import org.figuramc.figura.server.packets.s2c.S2CInitializeAvatarStreamPacket;
 import org.figuramc.figura.server.utils.*;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -249,6 +251,7 @@ public final class FiguraServerAvatarManager {
     }
 
     private void saveMetadata(Hash avatarHash, AvatarMetadata metadata) {
+        if (metadata == null) return;
         if (Events.call(new StoreAvatarMetadataEvent(avatarHash, metadata)).isCancelled()) return;
         var file = parent.getAvatarMetadata(avatarHash.get()).toFile();
         try (FileOutputStream fos = new FileOutputStream(file)) {
@@ -270,7 +273,7 @@ public final class FiguraServerAvatarManager {
     private class AvatarHandle {
         private final Hash hash;
         private AvatarData data;
-        private AvatarMetadata metadata;
+        private @Nullable AvatarMetadata metadata;
         private final ArrayList<AvatarOutcomingStream> streams = new ArrayList<>();
         private boolean markedForDeletion = false;
 
@@ -370,6 +373,7 @@ public final class FiguraServerAvatarManager {
             var s = streams.get(key);
             if (s.acceptDataChunk(data, finalChunk)) {
                 streams.entrySet().removeIf(e -> e.getValue().isFinished());
+                parent.sendPacket(uuid, new S2CAvatarReadyPacket(s.avatarId, new EHashPair(s.hash, s.ehash)));
             }
         }
 

--- a/server-common/src/main/java/org/figuramc/figura/server/avatars/FiguraServerAvatarManager.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/avatars/FiguraServerAvatarManager.java
@@ -50,7 +50,11 @@ public final class FiguraServerAvatarManager {
     }
 
     public AvatarMetadata getAvatarMetadata(Hash hash) {
-        return getAvatarHandle(hash).getMetadata();
+        try {
+            return getAvatarHandle(hash).getMetadata();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public void tick() {
@@ -282,31 +286,33 @@ public final class FiguraServerAvatarManager {
         }
 
         private void sendTo(UUID receiver, int streamId) {
-            streams.add(new AvatarOutcomingStream(receiver, getAvatarData(), streamId,
-                    hash, getMetadata().getOwnerEHash(receiver)));
+            try {
+                streams.add(new AvatarOutcomingStream(
+                        receiver, getAvatarData(), streamId,
+                        hash, getMetadata().getOwnerEHash(receiver)
+                ));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
 
-        private AvatarData getAvatarData() {
+        private AvatarData getAvatarData() throws IOException {
             if (data == null) {
                 data = loadAvatar();
             }
             return data;
         }
 
-        private AvatarData loadAvatar() {
+        private AvatarData loadAvatar() throws IOException {
             var event = Events.call(new StartLoadingAvatarEvent(hash));
             if (event.returned()) checkAndFinishLoadingAvatar(event.returnValue());
 
             var inst = FiguraServer.getInstance();
             Path avatarFile = inst.getAvatar(hash.get());
-            try {
-                FileInputStream fis = new FileInputStream(avatarFile.toFile());
-                byte[] data = fis.readAllBytes();
-                fis.close();
-                return checkAndFinishLoadingAvatar(data);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+            FileInputStream fis = new FileInputStream(avatarFile.toFile());
+            byte[] data = fis.readAllBytes();
+            fis.close();
+            return checkAndFinishLoadingAvatar(data);
         }
 
         private AvatarData checkAndFinishLoadingAvatar(byte[] data) {
@@ -315,32 +321,40 @@ public final class FiguraServerAvatarManager {
             return new AvatarData(data);
         }
 
-        private AvatarMetadata getMetadata() {
+        private AvatarMetadata getMetadata() throws IOException {
             if (metadata == null) {
                 metadata = loadMetadata();
+                if (metadata == null) throw new RuntimeException(String.format("The avatar metadata for %s is corrupt (empty file?!)", hash));
             }
             return metadata;
         }
 
-        private AvatarMetadata loadMetadata() {
+        private AvatarMetadata loadMetadata() throws IOException {
             var event = Events.call(new StartLoadingMetadataEvent(hash));
             if (event.returned()) return event.returnValue();
 
             var inst = FiguraServer.getInstance();
             Path avatarFile = inst.getAvatarMetadata(hash.get());
-            try {
-                FileInputStream fis = new FileInputStream(avatarFile.toFile());
-                byte[] data = fis.readAllBytes();
-                fis.close();
-                return AvatarMetadata.read(new String(data, StandardCharsets.UTF_8));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+            FileInputStream fis = new FileInputStream(avatarFile.toFile());
+            byte[] data = fis.readAllBytes();
+            fis.close();
+            return AvatarMetadata.read(new String(data, StandardCharsets.UTF_8));
         }
 
         private void tick() {
-            var data = getAvatarData();
-            var metadata = getMetadata();
+            AvatarData data;
+            AvatarMetadata metadata;
+            try {
+                data = getAvatarData();
+                metadata = getMetadata();
+            } catch (FileNotFoundException fileEx) {
+                FiguraServer.getInstance().logInfo(String.format("Throwing away avatar %s because its data is missing", hash));
+                markedForDeletion = true;
+                return;
+            } catch (IOException e) {
+                FiguraServer.getInstance().logError("Avatar handle ticking failed", e);
+                return;
+            }
 
             data.tick();
             if (metadata.canBeDeleted()) {
@@ -428,7 +442,8 @@ public final class FiguraServerAvatarManager {
                     saveAvatar(hash, avatarData);
 
                     // Creating a new avatar handle
-                    var avatarHandle = getAvatarHandle(hash);
+                    avatars.remove(hash);
+                    var avatarHandle = new AvatarHandle(hash);
                     avatarHandle.data = new AvatarData(avatarData);
 
                     // Creating empty metadata for this avatar with all the avatar owners
@@ -442,6 +457,9 @@ public final class FiguraServerAvatarManager {
                     saveMetadata(hash, metadata);
 
                     avatarHandle.metadata = metadata;
+
+                    // Avatar is now ready for use by main thread
+                    avatars.put(hash, avatarHandle);
 
                     // Finishing work of all streams
                     for (IncomingAvatarKey key: hashesToUploads.get(hash)) {

--- a/server-common/src/main/java/org/figuramc/figura/server/packets/Packets.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/packets/Packets.java
@@ -25,6 +25,7 @@ public class Packets {
         put(C2SUploadAvatarPacket.PACKET_ID, desc(CLIENT, C2SUploadAvatarPacket::new));
 
         put(S2CAvatarReadyPacket.PACKET_ID, desc(SERVER, S2CAvatarReadyPacket::new));
+        put(S2CAvatarDeletedPacket.PACKET_ID, desc(SERVER, S2CAvatarDeletedPacket::new));
         put(S2CRefusedPacket.PACKET_ID, desc(SERVER, empty(S2CRefusedPacket::new)));
         put(S2CBackendHandshakePacket.PACKET_ID, desc(SERVER, S2CBackendHandshakePacket::new));
         put(S2CConnectedPacket.PACKET_ID, desc(SERVER, S2CConnectedPacket::new));

--- a/server-common/src/main/java/org/figuramc/figura/server/packets/Packets.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/packets/Packets.java
@@ -24,6 +24,7 @@ public class Packets {
         put(C2SPingPacket.PACKET_ID, desc(CLIENT, C2SPingPacket::new));
         put(C2SUploadAvatarPacket.PACKET_ID, desc(CLIENT, C2SUploadAvatarPacket::new));
 
+        put(S2CAvatarReadyPacket.PACKET_ID, desc(SERVER, S2CAvatarReadyPacket::new));
         put(S2CRefusedPacket.PACKET_ID, desc(SERVER, empty(S2CRefusedPacket::new)));
         put(S2CBackendHandshakePacket.PACKET_ID, desc(SERVER, S2CBackendHandshakePacket::new));
         put(S2CConnectedPacket.PACKET_ID, desc(SERVER, S2CConnectedPacket::new));

--- a/server-common/src/main/java/org/figuramc/figura/server/packets/c2s/C2SDeleteAvatarPacket.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/packets/c2s/C2SDeleteAvatarPacket.java
@@ -7,7 +7,7 @@ import org.figuramc.figura.server.utils.Identifier;
 import java.nio.charset.StandardCharsets;
 
 public class C2SDeleteAvatarPacket implements Packet {
-    public static Identifier PACKET_ID = new Identifier("figura", "c2s/avatars/delete");
+    public static final Identifier PACKET_ID = new Identifier("figura", "c2s/avatars/delete");
 
     private final String avatarId;
 

--- a/server-common/src/main/java/org/figuramc/figura/server/packets/handlers/c2s/C2SDeleteAvatarPacketHandler.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/packets/handlers/c2s/C2SDeleteAvatarPacketHandler.java
@@ -3,6 +3,7 @@ package org.figuramc.figura.server.packets.handlers.c2s;
 import org.figuramc.figura.server.FiguraServer;
 import org.figuramc.figura.server.FiguraUser;
 import org.figuramc.figura.server.packets.c2s.C2SDeleteAvatarPacket;
+import org.figuramc.figura.server.packets.s2c.S2CAvatarDeletedPacket;
 import org.figuramc.figura.server.utils.IFriendlyByteBuf;
 
 public class C2SDeleteAvatarPacketHandler extends AuthorizedC2SPacketHandler<C2SDeleteAvatarPacket> {
@@ -14,6 +15,7 @@ public class C2SDeleteAvatarPacketHandler extends AuthorizedC2SPacketHandler<C2S
     protected void handle(FiguraUser sender, C2SDeleteAvatarPacket packet) {
         sender.removeOwnedAvatar(packet.avatarId());
         sender.removeEquippedAvatar();
+        sender.sendPacket(new S2CAvatarDeletedPacket(packet.avatarId()));
     }
 
     @Override

--- a/server-common/src/main/java/org/figuramc/figura/server/packets/handlers/c2s/C2SUploadAvatarPacketHandler.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/packets/handlers/c2s/C2SUploadAvatarPacketHandler.java
@@ -2,9 +2,11 @@ package org.figuramc.figura.server.packets.handlers.c2s;
 
 import org.figuramc.figura.server.FiguraServer;
 import org.figuramc.figura.server.FiguraUser;
+import org.figuramc.figura.server.avatars.EHashPair;
 import org.figuramc.figura.server.packets.AllowIncomingStreamPacket;
 import org.figuramc.figura.server.packets.CloseIncomingStreamPacket;
 import org.figuramc.figura.server.packets.c2s.C2SUploadAvatarPacket;
+import org.figuramc.figura.server.packets.s2c.S2CAvatarReadyPacket;
 import org.figuramc.figura.server.utils.IFriendlyByteBuf;
 import org.figuramc.figura.server.utils.StatusCode;
 
@@ -22,6 +24,7 @@ public class C2SUploadAvatarPacketHandler extends AuthorizedC2SPacketHandler<C2S
         if (avatarExists) {
             sender.replaceOrAddOwnedAvatar(packet.avatarId(), packet.hash(), packet.ehash());
             sender.sendPacket(new CloseIncomingStreamPacket(packet.streamId(), StatusCode.ALREADY_EXISTS));
+            sender.sendPacket(new S2CAvatarReadyPacket(packet.avatarId(), new EHashPair(packet.hash(), packet.ehash())));
         }
         else {
             parent.avatarManager().receiveAvatar(sender, packet.avatarId(), packet.streamId(), packet.hash(), packet.ehash());

--- a/server-common/src/main/java/org/figuramc/figura/server/packets/s2c/S2CAvatarDeletedPacket.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/packets/s2c/S2CAvatarDeletedPacket.java
@@ -1,0 +1,32 @@
+package org.figuramc.figura.server.packets.s2c;
+
+import org.figuramc.figura.server.avatars.EHashPair;
+import org.figuramc.figura.server.packets.Packet;
+import org.figuramc.figura.server.utils.Hash;
+import org.figuramc.figura.server.utils.IFriendlyByteBuf;
+import org.figuramc.figura.server.utils.Identifier;
+
+import java.nio.charset.StandardCharsets;
+
+public class S2CAvatarDeletedPacket implements Packet {
+    public static final Identifier PACKET_ID = new Identifier("figura", "s2c/avatar_deleted");
+    public final String avatarId;
+
+    public S2CAvatarDeletedPacket(String avatarId) {
+        this.avatarId = avatarId;
+    }
+
+    public S2CAvatarDeletedPacket(IFriendlyByteBuf buf) {
+        this.avatarId = new String(buf.readByteArray(256), StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public void write(IFriendlyByteBuf buf) {
+        buf.writeByteArray(avatarId.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public Identifier getId() {
+        return PACKET_ID;
+    }
+}

--- a/server-common/src/main/java/org/figuramc/figura/server/packets/s2c/S2CAvatarReadyPacket.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/packets/s2c/S2CAvatarReadyPacket.java
@@ -1,0 +1,39 @@
+package org.figuramc.figura.server.packets.s2c;
+
+import org.figuramc.figura.server.avatars.EHashPair;
+import org.figuramc.figura.server.packets.Packet;
+import org.figuramc.figura.server.utils.Hash;
+import org.figuramc.figura.server.utils.IFriendlyByteBuf;
+import org.figuramc.figura.server.utils.Identifier;
+
+import java.nio.charset.StandardCharsets;
+
+public class S2CAvatarReadyPacket implements Packet {
+    public static final Identifier PACKET_ID = new Identifier("figura", "s2c/avatar_ready");
+    public final String avatarId;
+    public final EHashPair ref;
+
+    public S2CAvatarReadyPacket(String avatarId, EHashPair ref) {
+        this.avatarId = avatarId;
+        this.ref = ref;
+    }
+
+    public S2CAvatarReadyPacket(IFriendlyByteBuf buf) {
+        this.avatarId = new String(buf.readByteArray(256), StandardCharsets.UTF_8);
+        Hash hash = buf.readHash();
+        Hash ehash = buf.readHash();
+        this.ref = new EHashPair(hash, ehash);
+    }
+
+    @Override
+    public void write(IFriendlyByteBuf buf) {
+        buf.writeByteArray(avatarId.getBytes(StandardCharsets.UTF_8));
+        buf.writeBytes(ref.hash().get());
+        buf.writeBytes(ref.ehash().get());
+    }
+
+    @Override
+    public Identifier getId() {
+        return PACKET_ID;
+    }
+}


### PR DESCRIPTION
* fix crash caused by race condition between network and server threads when uploading an avatar
* put error handling pretty much everywhere so errors don't take down the entire server
* new packet types for server to reply with when avatar uploads and deletions finish processing
  * uploading to Server Cloud now waits for the server to finish the upload and reply with `S2CAvatarReadyPacket` before equipping the avatar and displaying the upload toast
  * uploading to backend only now doesn't try to equip the avatar on FSB if it's connected
  * still tries to use the FSB avatar when uploading to both
  * client now displays the Avatar Deleted toast!
* corrupt avatar files (blank / missing) should now be handled much better (at least they don't crash now?)