### PR TITLE
Fix load() environment issue

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/FiguraLuaRuntime.java
+++ b/common/src/main/java/org/figuramc/figura/lua/FiguraLuaRuntime.java
@@ -304,10 +304,19 @@ public class FiguraLuaRuntime {
 
                 // get environment in which will be used to get global values from, does not make extra lookups outside this table
                 val = args.arg(3);
-                LuaTable environment = val.istable() ? val.checktable() : runtime.userGlobals;
+                LuaTable environment = val.istable() ? val.checktable() : null;
 
                 // create the function from arguments
-                return runtime.userGlobals.load(ld, chunkName, "t", environment);
+                LuaValue chunk = runtime.userGlobals.load(ld, chunkName, "t", runtime.userGlobals);
+                // adjust the globals so that the debug hooks function correctly *and* the environment also works
+                if (environment != null && chunk instanceof LuaClosure) {
+                    UpValue[] upvalues = ((LuaClosure) chunk).upValues;
+                    if (upvalues.length > 0 && upvalues[0].getValue() == runtime.userGlobals) {
+                        upvalues[0].setValue(environment);
+                    }
+                }
+
+                return chunk;
             } catch (LuaError e) {
                 return varargsOf(NIL, e.getMessageObject());
             }


### PR DESCRIPTION
should keep the actual environment replacement functionality working, but also keep tracebacks etc intact