### PR TITLE
Make sure all packets are sent when using FSB

### DIFF
--- a/common/src/main/java/org/figuramc/figura/backend2/NetworkStuff.java
+++ b/common/src/main/java/org/figuramc/figura/backend2/NetworkStuff.java
@@ -655,6 +655,12 @@ public class NetworkStuff {
 
 
     public static boolean isConnected() {
+        // when FSB is connected, it will handle all requests
+        // so we don't need to check the connection to the backend
+        // some code checks isConnected() to determine if it's ok to send packets
+        if (fsb().connected()) {
+            return true;
+        }
         return api != null && checkWS();
     }
 


### PR DESCRIPTION
While testing the FSB feature on my local server, I noticed that pings triggered from the action wheel were failing. After debugging, I discovered that

runPing ([link](https://github.com/FiguraMC/Figura/blob/febed5e76fddc5feb9fd42faa15aac1cb45bc677/common/src/main/java/org/figuramc/figura/backend2/NetworkStuff.java#L575))

depends on isConnected ([link](https://github.com/FiguraMC/Figura/blob/febed5e76fddc5feb9fd42faa15aac1cb45bc677/common/src/main/java/org/figuramc/figura/backend2/NetworkStuff.java#L657)).

However, when the FSB feature is enabled, isConnected() always returns false, which causes the ping workflow to be canceled immediately. This change adjusts the logic so that pings still proceed under FSB.

Special thanks to @lucaargolo for helping test this.
