### PR TITLE
Fine-grained control of Rate, size and count limits using meta permissions in FSB

### DIFF
--- a/fabric/src/main/java/org/figuramc/figura/fabric/FiguraServerFabric.java
+++ b/fabric/src/main/java/org/figuramc/figura/fabric/FiguraServerFabric.java
@@ -1,6 +1,7 @@
 package org.figuramc.figura.fabric;
 
 import io.netty.buffer.Unpooled;
+import me.lucko.fabric.api.permissions.v0.Options;
 import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.fabricmc.api.DedicatedServerModInitializer;
 import net.fabricmc.fabric.api.networking.v1.PacketSender;
@@ -12,10 +13,12 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import org.figuramc.figura.commands.fabric.FiguraServerCommandsFabric;
 import org.figuramc.figura.server.FiguraModServer;
+import org.figuramc.figura.server.FiguraPermissionNodes;
 import org.figuramc.figura.server.packets.Packet;
 import org.figuramc.figura.server.packets.handlers.c2s.C2SPacketHandler;
 import org.figuramc.figura.utils.FriendlyByteBufWrapper;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public class FiguraServerFabric extends FiguraModServer implements DedicatedServerModInitializer {
@@ -42,9 +45,15 @@ public class FiguraServerFabric extends FiguraModServer implements DedicatedServ
     }
 
     @Override
-    public boolean getPermission(UUID uuid, String permission) {
+    public boolean getPermission(UUID uuid, FiguraPermissionNodes permission) {
         ServerPlayer player = getServer().getPlayerList().getPlayer(uuid);
-        return player != null && Permissions.check(player, permission);
+        return player != null && Permissions.check(player, permission.toString());
+    }
+
+    @Override
+    public Optional<String> getOption(UUID uuid, FiguraPermissionNodes option) {
+        ServerPlayer player = getServer().getPlayerList().getPlayer(uuid);
+        return (player != null) ? Options.get(player, option.toString()) : Optional.empty();
     }
 
     private static class FabricServerHandler<P extends Packet> implements ServerPlayNetworking.PlayChannelHandler {

--- a/forge/src/main/java/org/figuramc/figura/forge/FiguraForgePermissions.java
+++ b/forge/src/main/java/org/figuramc/figura/forge/FiguraForgePermissions.java
@@ -8,6 +8,7 @@ import net.minecraftforge.server.permission.nodes.PermissionDynamicContext;
 import net.minecraftforge.server.permission.nodes.PermissionNode;
 import net.minecraftforge.server.permission.nodes.PermissionTypes;
 import org.figuramc.figura.server.FiguraModServer;
+import org.figuramc.figura.server.FiguraPermissionNodes;
 import org.figuramc.figura.server.FiguraPermissions;
 import org.figuramc.figura.server.utils.Pair;
 import org.jetbrains.annotations.Nullable;
@@ -17,25 +18,42 @@ import java.util.UUID;
 
 public class FiguraForgePermissions {
 
-    private static final HashMap<String, PermissionNode<?>> registeredPermission = new HashMap<>() {{
+    private static final HashMap<FiguraPermissionNodes, PermissionNode<?>> registeredPermission = new HashMap<>() {{
         FiguraPermissions.PERMISSIONS_LIST.forEach((pair) -> {
             put(pair.left(), createNode(pair));
         });
     }};
+    private static final HashMap<FiguraPermissionNodes, PermissionNode<?>> registeredOption = new HashMap<>() {{
+        FiguraPermissions.OPTIONS_LIST.forEach((pair) -> {
+            put(pair.left(), createOption(pair));
+        });
+    }};
 
-    public static PermissionNode<Boolean> createNode(Pair<String, Boolean> pair) {
-        String name = pair.left();
+    public static PermissionNode<Boolean> createNode(Pair<FiguraPermissionNodes, Boolean> pair) {
+        String name = pair.left().toString();
         boolean defaultVal = pair.right();
         return new PermissionNode<>(FiguraModServer.MOD_ID, name, PermissionTypes.BOOLEAN, (a,b,c) -> defaultVal);
+    }
+
+    public static PermissionNode<String> createOption(Pair<FiguraPermissionNodes, String> pair) {
+        String name = pair.left().toString();
+        String defaultVal = pair.right();
+        return new PermissionNode<>(FiguraModServer.MOD_ID, name, PermissionTypes.STRING, (a,b,c) -> defaultVal);
     }
 
     @SubscribeEvent
     public void registerPermissions(PermissionGatherEvent.Nodes event) {
         event.addNodes(registeredPermission.values());
+        event.addNodes(registeredOption.values());
     }
 
     @SuppressWarnings("unchecked")
-    public static PermissionNode<Boolean> getPermission(String permission) {
+    public static PermissionNode<Boolean> getPermission(FiguraPermissionNodes permission) {
         return (PermissionNode<Boolean>) registeredPermission.get(permission);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static PermissionNode<String> getOption(FiguraPermissionNodes option) {
+        return (PermissionNode<String>) registeredOption.get(option);
     }
 }

--- a/forge/src/main/java/org/figuramc/figura/forge/FiguraServerForge.java
+++ b/forge/src/main/java/org/figuramc/figura/forge/FiguraServerForge.java
@@ -9,9 +9,11 @@ import net.minecraftforge.network.PacketDistributor;
 import net.minecraftforge.server.permission.PermissionAPI;
 import net.minecraftforge.server.permission.nodes.PermissionNode;
 import org.figuramc.figura.server.FiguraModServer;
+import org.figuramc.figura.server.FiguraPermissionNodes;
 import org.figuramc.figura.server.packets.Packet;
 import org.figuramc.figura.utils.FriendlyByteBufWrapper;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public class FiguraServerForge extends FiguraModServer {
@@ -27,9 +29,22 @@ public class FiguraServerForge extends FiguraModServer {
     }
 
     @Override
-    public boolean getPermission(UUID player, String permission) {
+    public boolean getPermission(UUID player, FiguraPermissionNodes permission) {
         ServerPlayer pl = getServer().getPlayerList().getPlayer(player);
         PermissionNode<Boolean> perm = FiguraForgePermissions.getPermission(permission);
         return pl != null && perm != null && PermissionAPI.getPermission(pl, perm);
     }
+
+    @Override
+    public Optional<String> getOption(UUID player, FiguraPermissionNodes permission) {
+        ServerPlayer pl = getServer().getPlayerList().getPlayer(player);
+        PermissionNode<String> perm = FiguraForgePermissions.getOption(permission);
+        if (pl == null || perm == null) {
+            return Optional.empty();
+        }
+        String value = PermissionAPI.getPermission(pl, perm);
+        return Optional.of(value);
+    }
+
+
 }

--- a/server-common/src/main/java/org/figuramc/figura/server/FiguraPermissionNodes.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/FiguraPermissionNodes.java
@@ -25,4 +25,13 @@ public enum FiguraPermissionNodes {
     public String toString() {
         return node;
     }
+
+    public static FiguraPermissionNodes fromString(String node) {
+        for (FiguraPermissionNodes permissionNode : values()) {
+            if (permissionNode.node.equalsIgnoreCase(node)) {
+                return permissionNode;
+            }
+        }
+        throw new IllegalArgumentException("No permission node found for: " + node);
+    }
 }

--- a/server-common/src/main/java/org/figuramc/figura/server/FiguraPermissionNodes.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/FiguraPermissionNodes.java
@@ -11,7 +11,7 @@ public enum FiguraPermissionNodes {
 
     FIGURA_PINGS_SIZELIMIT("figura.pings.sizelimit"),
 
-    FIGURA_AVATARS_SIZELIMIT("figura.avatars.send"),
+    FIGURA_AVATARS_SIZELIMIT("figura.avatars.sizelimit"),
 
     FIGURA_AVATARS_COUNTLIMIT("figura.avatars.countlimit");
 

--- a/server-common/src/main/java/org/figuramc/figura/server/FiguraPermissionNodes.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/FiguraPermissionNodes.java
@@ -1,0 +1,28 @@
+package org.figuramc.figura.server;
+
+public enum FiguraPermissionNodes {
+    FIGURA_AVATARS_IMMORTALIZE("figura.avatars.immortalize"),
+
+    FIGURA_AVATARS_SET("figura.avatars.set"),
+
+    FIGURA_AVATARS_CLEAR("figura.avatars.clear"),
+
+    FIGURA_PINGS_RATELIMIT("figura.pings.ratelimit"),
+
+    FIGURA_PINGS_SIZELIMIT("figura.pings.sizelimit"),
+
+    FIGURA_AVATARS_SIZELIMIT("figura.avatars.send"),
+
+    FIGURA_AVATARS_COUNTLIMIT("figura.avatars.countlimit");
+
+
+    private final String node;
+
+    FiguraPermissionNodes(String node) {
+        this.node = node;
+    }
+
+    public String toString() {
+        return node;
+    }
+}

--- a/server-common/src/main/java/org/figuramc/figura/server/FiguraPermissions.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/FiguraPermissions.java
@@ -1,12 +1,19 @@
 package org.figuramc.figura.server;
 
 import org.figuramc.figura.server.utils.Pair;
+import static org.figuramc.figura.server.FiguraPermissionNodes.*;
 
 import java.util.List;
 
 public class FiguraPermissions {
-    public static final List<Pair<String, Boolean>> PERMISSIONS_LIST = List.of(
-            Pair.of("figura.avatars.immortalize", false),
-            Pair.of("figura.avatars.set", false)
+    public static final List<Pair<FiguraPermissionNodes, Boolean>> PERMISSIONS_LIST = List.of(
+            Pair.of(FIGURA_AVATARS_IMMORTALIZE, false),
+            Pair.of(FIGURA_AVATARS_SET, false)
+    );
+    public static final List<Pair<FiguraPermissionNodes, String>> OPTIONS_LIST = List.of(
+            Pair.of(FIGURA_PINGS_RATELIMIT, 32+""),
+            Pair.of(FIGURA_PINGS_SIZELIMIT, 1024+""),
+            Pair.of(FIGURA_AVATARS_SIZELIMIT, 102400+""),
+            Pair.of(FIGURA_AVATARS_COUNTLIMIT, 1+"")
     );
 }

--- a/server-common/src/main/java/org/figuramc/figura/server/FiguraServer.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/FiguraServer.java
@@ -149,14 +149,14 @@ public abstract class FiguraServer {
         userManager().tick();
     }
 
-    public final S2CBackendHandshakePacket getHandshake() {
+    public final S2CBackendHandshakePacket getHandshake(UUID newUser) {
         ArrayList<UUID> connectedUsers = new ArrayList<>();
         userManager.forEachUser(user -> connectedUsers.add(user.uuid()));
         return new S2CBackendHandshakePacket(
-                config.pingsRateLimit(),
-                config.pingsSizeLimit(),
-                config.avatarSizeLimit(),
-                config.avatarsCountLimit(),
+                Math.min(config.pingsRateLimit(), Integer.parseInt(getOption(newUser, FiguraPermissionNodes.FIGURA_PINGS_RATELIMIT).orElse(config.pingsRateLimit() + ""))),
+                Math.min(config.pingsSizeLimit(), Integer.parseInt(getOption(newUser, FiguraPermissionNodes.FIGURA_PINGS_SIZELIMIT).orElse(config.pingsSizeLimit() + ""))),
+                Math.min(config.avatarSizeLimit(), Integer.parseInt(getOption(newUser, FiguraPermissionNodes.FIGURA_AVATARS_SIZELIMIT).orElse(config.avatarSizeLimit() + ""))),
+                Math.min(config.avatarsCountLimit(), Integer.parseInt(getOption(newUser, FiguraPermissionNodes.FIGURA_AVATARS_COUNTLIMIT).orElse(config.avatarsCountLimit() + ""))),
                 connectedUsers
         );
     }
@@ -179,7 +179,8 @@ public abstract class FiguraServer {
 
     protected abstract void sendPacketInternal(UUID receiver, Packet packet);
 
-    public abstract boolean getPermission(UUID player, String permission);
+    public abstract boolean getPermission(UUID player, FiguraPermissionNodes permission);
+    public abstract Optional<String> getOption(UUID player, FiguraPermissionNodes permission);
     public abstract void sendMessage(UUID receiver, JsonObject component);
 
     public FiguraServerAvatarManager avatarManager() {

--- a/server-common/src/main/java/org/figuramc/figura/server/FiguraServer.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/FiguraServer.java
@@ -153,10 +153,10 @@ public abstract class FiguraServer {
         ArrayList<UUID> connectedUsers = new ArrayList<>();
         userManager.forEachUser(user -> connectedUsers.add(user.uuid()));
         return new S2CBackendHandshakePacket(
-                Math.min(config.pingsRateLimit(), Integer.parseInt(getOption(newUser, FiguraPermissionNodes.FIGURA_PINGS_RATELIMIT).orElse(config.pingsRateLimit() + ""))),
-                Math.min(config.pingsSizeLimit(), Integer.parseInt(getOption(newUser, FiguraPermissionNodes.FIGURA_PINGS_SIZELIMIT).orElse(config.pingsSizeLimit() + ""))),
-                Math.min(config.avatarSizeLimit(), Integer.parseInt(getOption(newUser, FiguraPermissionNodes.FIGURA_AVATARS_SIZELIMIT).orElse(config.avatarSizeLimit() + ""))),
-                Math.min(config.avatarsCountLimit(), Integer.parseInt(getOption(newUser, FiguraPermissionNodes.FIGURA_AVATARS_COUNTLIMIT).orElse(config.avatarsCountLimit() + ""))),
+                config.pingsRateLimit(this, newUser),
+                config.pingsSizeLimit(this, newUser),
+                config.avatarSizeLimit(this, newUser),
+                config.avatarsCountLimit(this, newUser),
                 connectedUsers
         );
     }

--- a/server-common/src/main/java/org/figuramc/figura/server/FiguraServerConfig.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/FiguraServerConfig.java
@@ -2,6 +2,8 @@ package org.figuramc.figura.server;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.UUID;
+
 public final class FiguraServerConfig {
     @SerializedName("pingsRateLimit")
     private int pingsRateLimit = 32;
@@ -13,19 +15,19 @@ public final class FiguraServerConfig {
     @SerializedName("avatarCountLimit")
     private int avatarsCountLimit = 1;
 
-    public int pingsRateLimit() {
-        return pingsRateLimit;
+    public int pingsRateLimit(FiguraServer server, UUID player) {
+        return Integer.parseInt(server.getOption(player, FiguraPermissionNodes.FIGURA_PINGS_RATELIMIT).orElse(pingsRateLimit + ""));
     }
 
-    public int pingsSizeLimit() {
-        return pingsSizeLimit;
+    public int pingsSizeLimit(FiguraServer server, UUID player) {
+        return Integer.parseInt(server.getOption(player, FiguraPermissionNodes.FIGURA_PINGS_SIZELIMIT).orElse(pingsSizeLimit + ""));
     }
 
-    public int avatarSizeLimit() {
-        return avatarSizeLimit;
+    public int avatarSizeLimit(FiguraServer server, UUID player) {
+        return Integer.parseInt(server.getOption(player, FiguraPermissionNodes.FIGURA_AVATARS_SIZELIMIT).orElse(avatarSizeLimit + ""));
     }
 
-    public int avatarsCountLimit() {
-        return avatarsCountLimit;
+    public int avatarsCountLimit(FiguraServer server, UUID player) {
+        return Integer.parseInt(server.getOption(player, FiguraPermissionNodes.FIGURA_AVATARS_COUNTLIMIT).orElse(avatarsCountLimit + ""));
     }
 }

--- a/server-common/src/main/java/org/figuramc/figura/server/avatars/FiguraServerAvatarManager.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/avatars/FiguraServerAvatarManager.java
@@ -1,5 +1,6 @@
 package org.figuramc.figura.server.avatars;
 
+import org.figuramc.figura.server.FiguraPermissionNodes;
 import org.figuramc.figura.server.FiguraServer;
 import org.figuramc.figura.server.FiguraUser;
 import org.figuramc.figura.server.events.Events;
@@ -413,7 +414,7 @@ public final class FiguraServerAvatarManager {
             private boolean acceptDataChunk(byte[] chunk, boolean finalChunk) {
                 size += chunk.length;
                 // In case if avatar size is exceeded - closing the stream and removing it from handler.
-                if (size > parent.config().avatarSizeLimit() &&
+                if (size > Math.min(parent.config().avatarSizeLimit(), Integer.parseInt(parent.getOption(uploader, FiguraPermissionNodes.FIGURA_AVATARS_SIZELIMIT).orElse(parent.config().avatarSizeLimit() + ""))) &&
                     !Events.call(new AvatarUploadSizeExceedEvent(uploader, size)).isCancelled()) {
                     close(StatusCode.MAX_AVATAR_SIZE_EXCEEDED);
                     return true;

--- a/server-common/src/main/java/org/figuramc/figura/server/avatars/FiguraServerAvatarManager.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/avatars/FiguraServerAvatarManager.java
@@ -414,7 +414,7 @@ public final class FiguraServerAvatarManager {
             private boolean acceptDataChunk(byte[] chunk, boolean finalChunk) {
                 size += chunk.length;
                 // In case if avatar size is exceeded - closing the stream and removing it from handler.
-                if (size > Math.min(parent.config().avatarSizeLimit(), Integer.parseInt(parent.getOption(uploader, FiguraPermissionNodes.FIGURA_AVATARS_SIZELIMIT).orElse(parent.config().avatarSizeLimit() + ""))) &&
+                if (size > parent.config().avatarSizeLimit(parent, uploader) &&
                     !Events.call(new AvatarUploadSizeExceedEvent(uploader, size)).isCancelled()) {
                     close(StatusCode.MAX_AVATAR_SIZE_EXCEEDED);
                     return true;

--- a/server-common/src/main/java/org/figuramc/figura/server/commands/FiguraAvatarCommand.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/commands/FiguraAvatarCommand.java
@@ -7,6 +7,7 @@ import com.mojang.brigadier.context.CommandContext;
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 
+import org.figuramc.figura.server.FiguraPermissionNodes;
 import org.figuramc.figura.server.FiguraServer;
 import org.figuramc.figura.server.FiguraUser;
 import org.figuramc.figura.server.avatars.EHashPair;
@@ -38,7 +39,7 @@ public class FiguraAvatarCommand {
 
     private static LiteralArgumentBuilder<FiguraServerCommandSource> immortalizeCommand() {
         LiteralArgumentBuilder<FiguraServerCommandSource> immortalize = literal("immortalize");
-        immortalize.requires(permissionCheck("figura.avatars.immortalize"));
+        immortalize.requires(permissionCheck(FiguraPermissionNodes.FIGURA_AVATARS_IMMORTALIZE));
         immortalize.executes(FiguraAvatarCommand::immortalizeEquippedAvatar);
 
         RequiredArgumentBuilder<FiguraServerCommandSource, String> immortalizeSpecific = argument("avatar_hash", StringArgumentType.string());
@@ -51,7 +52,7 @@ public class FiguraAvatarCommand {
 
     private static LiteralArgumentBuilder<FiguraServerCommandSource> setAvatarCommand() {
         LiteralArgumentBuilder<FiguraServerCommandSource> setAvatar = literal("set");
-        setAvatar.requires(permissionCheck("figura.avatars.set"));
+        setAvatar.requires(permissionCheck(FiguraPermissionNodes.FIGURA_AVATARS_SET));
 
         RequiredArgumentBuilder<FiguraServerCommandSource, String> target = argument("target", StringArgumentType.string());
         target.executes(FiguraAvatarCommand::setAvatarEquipped);
@@ -66,7 +67,7 @@ public class FiguraAvatarCommand {
 
     private static LiteralArgumentBuilder<FiguraServerCommandSource> clearAvatarCommand() {
         LiteralArgumentBuilder<FiguraServerCommandSource> clearAvatar = literal("clear");
-        clearAvatar.requires(permissionCheck("figura.avatars.clear"));
+        clearAvatar.requires(permissionCheck(FiguraPermissionNodes.FIGURA_AVATARS_CLEAR));
 
         RequiredArgumentBuilder<FiguraServerCommandSource, String> target = argument("target", StringArgumentType.string());
         target.executes(FiguraAvatarCommand::clearAvatar);

--- a/server-common/src/main/java/org/figuramc/figura/server/commands/FiguraServerCommandSource.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/commands/FiguraServerCommandSource.java
@@ -17,7 +17,7 @@ public interface FiguraServerCommandSource {
         return uuid != null ? getServer().userManager().getUser(uuid) : null;
     }
     default boolean permission(String permission) {
-        return getServer().getPermission(getExecutorUUID(), FiguraPermissionNodes.valueOf(permission));
+        return getServer().getPermission(getExecutorUUID(), FiguraPermissionNodes.fromString(permission));
     }
     default void sendComponent(JsonObject message) {
         getServer().sendMessage(getExecutorUUID(), message);

--- a/server-common/src/main/java/org/figuramc/figura/server/commands/FiguraServerCommandSource.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/commands/FiguraServerCommandSource.java
@@ -1,6 +1,7 @@
 package org.figuramc.figura.server.commands;
 
 import com.google.gson.JsonObject;
+import org.figuramc.figura.server.FiguraPermissionNodes;
 import org.figuramc.figura.server.FiguraServer;
 import org.figuramc.figura.server.FiguraUser;
 
@@ -16,7 +17,7 @@ public interface FiguraServerCommandSource {
         return uuid != null ? getServer().userManager().getUser(uuid) : null;
     }
     default boolean permission(String permission) {
-        return getServer().getPermission(getExecutorUUID(), permission);
+        return getServer().getPermission(getExecutorUUID(), FiguraPermissionNodes.valueOf(permission));
     }
     default void sendComponent(JsonObject message) {
         getServer().sendMessage(getExecutorUUID(), message);

--- a/server-common/src/main/java/org/figuramc/figura/server/commands/FiguraServerCommands.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/commands/FiguraServerCommands.java
@@ -2,6 +2,7 @@ package org.figuramc.figura.server.commands;
 
 
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import org.figuramc.figura.server.FiguraPermissionNodes;
 import org.figuramc.figura.server.FiguraServer;
 
 import java.util.function.Predicate;
@@ -18,16 +19,16 @@ public class FiguraServerCommands {
     }
 
     public static class PermissionPredicate implements Predicate<FiguraServerCommandSource> {
-        public final String permission;
+        public final FiguraPermissionNodes permission;
 
-        public PermissionPredicate(String permission) {
+        public PermissionPredicate(FiguraPermissionNodes permission) {
             this.permission = permission;
         }
 
         @Override
         public boolean test(FiguraServerCommandSource source) {
             try {
-                return source.permission(permission);
+                return source.permission(permission.toString());
             }
             catch (Exception e) {
                 FiguraServer.getInstance().logError("Error occured while processing permission check: ", e);
@@ -36,7 +37,7 @@ public class FiguraServerCommands {
         }
     }
 
-    public static PermissionPredicate permissionCheck(String permission) {
+    public static PermissionPredicate permissionCheck(FiguraPermissionNodes permission) {
         return new PermissionPredicate(permission);
     }
 }

--- a/server-common/src/main/java/org/figuramc/figura/server/packets/handlers/c2s/C2SHandshakeHandler.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/packets/handlers/c2s/C2SHandshakeHandler.java
@@ -31,7 +31,7 @@ public class C2SHandshakeHandler implements C2SPacketHandler<C2SBackendHandshake
         else {
             FiguraUserManager manager = parent.userManager();
             var user = manager.setupOnlinePlayer(sender);
-            user.sendPacket(parent.getHandshake());
+            user.sendPacket(parent.getHandshake(sender));
             manager.forEachUser(u -> {
                 if (u != user) {
                     u.sendPacket(new S2CConnectedPacket(user.uuid()));

--- a/server-common/src/main/java/org/figuramc/figura/server/packets/handlers/c2s/C2SPingPacketHandler.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/packets/handlers/c2s/C2SPingPacketHandler.java
@@ -16,10 +16,10 @@ public class C2SPingPacketHandler extends AuthorizedC2SPacketHandler<C2SPingPack
     @Override
     protected void handle(FiguraUser sender, C2SPingPacket packet) {
         var counter = sender.pingCounter();
-        if (counter.pingsSent() > Math.min(parent.config().pingsRateLimit(), Integer.parseInt(parent.getOption(sender.uuid(), FiguraPermissionNodes.FIGURA_PINGS_RATELIMIT).orElse(parent.config().pingsRateLimit() + "")))) {
+        if (counter.pingsSent() > parent.config().pingsRateLimit(parent, sender.uuid())) {
             sender.sendPacket(new S2CPingErrorPacket(S2CPingErrorPacket.Error.RATE_LIMIT));
         }
-        if (counter.bytesSent() + packet.data().length > Math.min(parent.config().pingsSizeLimit(), Integer.parseInt(parent.getOption(sender.uuid(), FiguraPermissionNodes.FIGURA_PINGS_SIZELIMIT).orElse(parent.config().pingsSizeLimit() + "")))) {
+        if (counter.bytesSent() + packet.data().length > parent.config().pingsSizeLimit(parent, sender.uuid())) {
             sender.sendPacket(new S2CPingErrorPacket(S2CPingErrorPacket.Error.PING_SIZE));
         }
         counter.addPing(packet.data().length);

--- a/server-common/src/main/java/org/figuramc/figura/server/packets/handlers/c2s/C2SPingPacketHandler.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/packets/handlers/c2s/C2SPingPacketHandler.java
@@ -1,5 +1,6 @@
 package org.figuramc.figura.server.packets.handlers.c2s;
 
+import org.figuramc.figura.server.FiguraPermissionNodes;
 import org.figuramc.figura.server.FiguraServer;
 import org.figuramc.figura.server.FiguraUser;
 import org.figuramc.figura.server.packets.c2s.C2SPingPacket;
@@ -15,10 +16,10 @@ public class C2SPingPacketHandler extends AuthorizedC2SPacketHandler<C2SPingPack
     @Override
     protected void handle(FiguraUser sender, C2SPingPacket packet) {
         var counter = sender.pingCounter();
-        if (counter.pingsSent() > parent.config().pingsRateLimit()) {
+        if (counter.pingsSent() > Math.min(parent.config().pingsRateLimit(), Integer.parseInt(parent.getOption(sender.uuid(), FiguraPermissionNodes.FIGURA_PINGS_RATELIMIT).orElse(parent.config().pingsRateLimit() + "")))) {
             sender.sendPacket(new S2CPingErrorPacket(S2CPingErrorPacket.Error.RATE_LIMIT));
         }
-        if (counter.bytesSent() + packet.data().length > parent.config().pingsSizeLimit()) {
+        if (counter.bytesSent() + packet.data().length > Math.min(parent.config().pingsSizeLimit(), Integer.parseInt(parent.getOption(sender.uuid(), FiguraPermissionNodes.FIGURA_PINGS_SIZELIMIT).orElse(parent.config().pingsSizeLimit() + "")))) {
             sender.sendPacket(new S2CPingErrorPacket(S2CPingErrorPacket.Error.PING_SIZE));
         }
         counter.addPing(packet.data().length);

--- a/server-common/src/main/java/org/figuramc/figura/server/packets/handlers/c2s/C2SUploadAvatarPacketHandler.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/packets/handlers/c2s/C2SUploadAvatarPacketHandler.java
@@ -19,7 +19,7 @@ public class C2SUploadAvatarPacketHandler extends AuthorizedC2SPacketHandler<C2S
     @Override
     protected void handle(FiguraUser sender, C2SUploadAvatarPacket packet) {
         boolean avatarExists = parent.avatarManager().avatarExists(packet.hash());
-        if (getNewAvatarsCount(sender, packet.avatarId()) > Math.min(parent.config().avatarsCountLimit(), Integer.parseInt(parent.getOption(sender.uuid(), FiguraPermissionNodes.FIGURA_AVATARS_COUNTLIMIT).orElse(parent.config().avatarsCountLimit() + "")))) {
+        if (getNewAvatarsCount(sender, packet.avatarId()) > parent.config().avatarsCountLimit(parent,sender.uuid())) {
             sender.sendPacket(new CloseIncomingStreamPacket(packet.streamId(), StatusCode.TOO_MANY_AVATARS));
         }
         if (avatarExists) {

--- a/server-common/src/main/java/org/figuramc/figura/server/packets/handlers/c2s/C2SUploadAvatarPacketHandler.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/packets/handlers/c2s/C2SUploadAvatarPacketHandler.java
@@ -1,5 +1,6 @@
 package org.figuramc.figura.server.packets.handlers.c2s;
 
+import org.figuramc.figura.server.FiguraPermissionNodes;
 import org.figuramc.figura.server.FiguraServer;
 import org.figuramc.figura.server.FiguraUser;
 import org.figuramc.figura.server.avatars.EHashPair;
@@ -18,7 +19,7 @@ public class C2SUploadAvatarPacketHandler extends AuthorizedC2SPacketHandler<C2S
     @Override
     protected void handle(FiguraUser sender, C2SUploadAvatarPacket packet) {
         boolean avatarExists = parent.avatarManager().avatarExists(packet.hash());
-        if (getNewAvatarsCount(sender, packet.avatarId()) > parent.config().avatarsCountLimit()) {
+        if (getNewAvatarsCount(sender, packet.avatarId()) > Math.min(parent.config().avatarsCountLimit(), Integer.parseInt(parent.getOption(sender.uuid(), FiguraPermissionNodes.FIGURA_AVATARS_COUNTLIMIT).orElse(parent.config().avatarsCountLimit() + "")))) {
             sender.sendPacket(new CloseIncomingStreamPacket(packet.streamId(), StatusCode.TOO_MANY_AVATARS));
         }
         if (avatarExists) {

--- a/spigot/src/main/java/org/figuramc/figura/server/FiguraServerSpigot.java
+++ b/spigot/src/main/java/org/figuramc/figura/server/FiguraServerSpigot.java
@@ -4,6 +4,8 @@ import com.google.gson.JsonObject;
 import net.md_5.bungee.chat.ComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.metadata.MetadataValue;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.messaging.PluginMessageListener;
 import org.figuramc.figura.server.packets.Packet;
 import org.figuramc.figura.server.packets.handlers.c2s.C2SPacketHandler;
@@ -14,6 +16,8 @@ import org.figuramc.figura.server.utils.OutputStreamByteBuf;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.logging.Level;
 
@@ -56,9 +60,17 @@ public class FiguraServerSpigot extends FiguraServer implements PluginMessageLis
     }
 
     @Override
-    public boolean getPermission(UUID player, String permission) {
+    public boolean getPermission(UUID player, FiguraPermissionNodes permission) {
         Player pl = parent.getServer().getPlayer(player);
-        return pl != null && pl.hasPermission(permission);
+        return pl != null && pl.hasPermission(permission.toString());
+    }
+
+    @Override
+    public Optional<String> getOption(UUID player, FiguraPermissionNodes permission) {
+        Player pl = parent.getServer().getPlayer(player);
+        if (pl == null) return Optional.empty();
+        return pl.getMetadata(permission.toString()).stream().filter(metadataValue -> Objects.equals(metadataValue.getOwningPlugin(), parent))
+                .map(MetadataValue::asString).findFirst();
     }
 
     @Override


### PR DESCRIPTION
And unify permission nodes under its own enum for consistency