### PR TITLE
Remove unnecessary throw

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/world/WorldAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/world/WorldAPI.java
@@ -150,9 +150,6 @@ public class WorldAPI {
                 Math.min(min.getY() + 8, max.getY()),
                 Math.min(min.getZ() + 8, max.getZ())
         );
-        if (min.compareTo(max) > 0) {
-            throw new LuaError("Your max value can't be smaller than your min!");
-        }
         Level world = getCurrentWorld();
         if (!world.hasChunksAt(min, max))
             return list;


### PR DESCRIPTION
Removes an unnecessary throw in WorldAPI's getBlocks function. Minecraft already sorts positions.