### PR TITLE
perf: compile Lua-based animation values only once

### DIFF
--- a/common/src/main/java/org/figuramc/figura/animation/Animation.java
+++ b/common/src/main/java/org/figuramc/figura/animation/Animation.java
@@ -31,6 +31,7 @@ public class Animation {
 
     protected final List<Map.Entry<FiguraModelPart, List<Animation.AnimationChannel>>> animationParts = new ArrayList<>();
     private final Map<Float, LuaValue> codeFrames = new HashMap<>();
+    private final Map<Float, String> codeFrameQueue = new HashMap<>();
 
     // -- player variables -- // 
 
@@ -120,8 +121,23 @@ public class Animation {
             playCode(this.lastTime, this.frameTime);
     }
 
+    private void compileCode() {
+        Iterator<Map.Entry<Float, String>> iter = codeFrameQueue.entrySet().iterator();
+        while (iter.hasNext()) {
+            Map.Entry<Float, String> item = iter.next();
+            LuaValue chunk = owner.loadScript("animations." + modelName + "." + name, item.getValue());
+            if (chunk != null) {
+                codeFrames.put(item.getKey(), chunk);
+                iter.remove();
+            }
+        }
+    }
+
     public void playCode(float minTime, float maxTime) {
-        if (owner.luaRuntime == null || codeFrames.isEmpty())
+        if (owner.luaRuntime == null)
+            return;
+        compileCode();
+        if (codeFrames.isEmpty())
             return;
 
         if (maxTime < minTime) {
@@ -275,8 +291,7 @@ public class Animation {
             value = "animation.new_code"
     )
     public Animation newCode(float time, @LuaNotNil String data) {
-        LuaValue chunk = owner.loadScript("animations." + modelName + "." + name, data);
-        codeFrames.put(Math.max(time, 0f), chunk);
+        codeFrameQueue.put(Math.max(time, 0f), data);
         return this;
     }
 

--- a/common/src/main/java/org/figuramc/figura/animation/Animation.java
+++ b/common/src/main/java/org/figuramc/figura/animation/Animation.java
@@ -30,7 +30,7 @@ public class Animation {
     // -- keyframes -- // 
 
     protected final List<Map.Entry<FiguraModelPart, List<Animation.AnimationChannel>>> animationParts = new ArrayList<>();
-    private final Map<Float, String> codeFrames = new HashMap<>();
+    private final Map<Float, LuaValue> codeFrames = new HashMap<>();
 
     // -- player variables -- // 
 
@@ -121,7 +121,7 @@ public class Animation {
     }
 
     public void playCode(float minTime, float maxTime) {
-        if (owner.luaRuntime == null || codeFrames.keySet().isEmpty())
+        if (owner.luaRuntime == null || codeFrames.isEmpty())
             return;
 
         if (maxTime < minTime) {
@@ -133,8 +133,7 @@ public class Animation {
         for (Float codeTime : codeFrames.keySet()) {
             if (codeTime >= minTime && codeTime < maxTime) {
                 try {
-                    LuaValue value = owner.loadScript("animations." + modelName + "." + name, codeFrames.get(codeTime));
-                    owner.run(value, owner.animation, this);
+                    owner.run(codeFrames.get(codeTime), owner.animation, this);
                 } catch (Exception e) {
                     owner.luaRuntime.error(e);
                 }
@@ -276,7 +275,8 @@ public class Animation {
             value = "animation.new_code"
     )
     public Animation newCode(float time, @LuaNotNil String data) {
-        codeFrames.put(Math.max(time, 0f), data);
+        LuaValue chunk = owner.loadScript("animations." + modelName + "." + name, data);
+        codeFrames.put(Math.max(time, 0f), chunk);
         return this;
     }
 

--- a/common/src/main/java/org/figuramc/figura/animation/Keyframe.java
+++ b/common/src/main/java/org/figuramc/figura/animation/Keyframe.java
@@ -1,7 +1,6 @@
 package org.figuramc.figura.animation;
 
 import com.mojang.datafixers.util.Pair;
-import org.figuramc.figura.FiguraMod;
 import org.figuramc.figura.avatar.Avatar;
 import org.figuramc.figura.math.vector.FiguraVec3;
 import org.luaj.vm2.LuaError;
@@ -9,6 +8,34 @@ import org.luaj.vm2.LuaValue;
 import org.luaj.vm2.Varargs;
 
 public class Keyframe implements Comparable<Keyframe> {
+    /**
+     * <p>
+     * wannabe <code>Either&lt;Double, LuaValue&gt;</code>
+     * (because we have our own {@link org.figuramc.figura.server.utils.Either}, but it's in the server code so we can't use it)
+     * </p>
+     *
+     * <p>(the presence or absence of {@link KeyframeValue#function} implies which value is the "real" one)</p>
+     * <p>{@link KeyframeValue#chunkName} is also stored in here so that we don't have to dig it out of the function</p>
+     */
+    public static class KeyframeValue {
+        public final double literal;
+        public final LuaValue function;
+        public final String chunkName;
+
+        private KeyframeValue(double literal, LuaValue function, String chunkName) {
+            this.literal = literal;
+            this.function = function;
+            this.chunkName = chunkName;
+        }
+
+        public static KeyframeValue literal(double literal) {
+            return new KeyframeValue(literal, null, null);
+        }
+
+        public static KeyframeValue function(LuaValue function, String chunkName) {
+            return new KeyframeValue(0.0, function, chunkName);
+        }
+    }
 
     private final Avatar owner;
     private final Animation animation;
@@ -16,11 +43,22 @@ public class Keyframe implements Comparable<Keyframe> {
     private final Interpolation interpolation;
     private final FiguraVec3 targetA, targetB;
     private final String[] aCode, bCode;
-    private final String chunkName;
     private final FiguraVec3 bezierLeft, bezierRight;
     private final FiguraVec3 bezierLeftTime, bezierRightTime;
 
-    public Keyframe(Avatar owner, Animation animation, float time, Interpolation interpolation, Pair<FiguraVec3, String[]> a, Pair<FiguraVec3, String[]> b, FiguraVec3 bezierLeft, FiguraVec3 bezierRight, FiguraVec3 bezierLeftTime, FiguraVec3 bezierRightTime) {
+    private final KeyframeValue[] aCache = {null, null, null};
+    private final KeyframeValue[] bCache = {null, null, null};
+
+    public Keyframe(Avatar owner,
+                    Animation animation,
+                    float time,
+                    Interpolation interpolation,
+                    Pair<FiguraVec3, String[]> a,
+                    Pair<FiguraVec3, String[]> b,
+                    FiguraVec3 bezierLeft,
+                    FiguraVec3 bezierRight,
+                    FiguraVec3 bezierLeftTime,
+                    FiguraVec3 bezierRightTime) {
         this.owner = owner;
         this.animation = animation;
         this.time = time;
@@ -29,7 +67,6 @@ public class Keyframe implements Comparable<Keyframe> {
         this.targetB = b.getFirst();
         this.aCode = a.getSecond();
         this.bCode = b.getSecond();
-        this.chunkName = animation.getName() + " keyframe (" + time + "s)";
         this.bezierLeft = bezierLeft;
         this.bezierRight = bezierRight;
         this.bezierLeftTime = bezierLeftTime;
@@ -37,50 +74,99 @@ public class Keyframe implements Comparable<Keyframe> {
     }
 
     public FiguraVec3 getTargetA(float delta) {
-        return targetA != null ? targetA.copy() : FiguraVec3.of(parseStringData(aCode[0], delta), parseStringData(aCode[1], delta), parseStringData(aCode[2], delta));
+        return targetA != null ? targetA.copy() : FiguraVec3.of(getA(0, delta), getA(1, delta), getA(2, delta));
     }
 
     public FiguraVec3 getTargetB(float delta) {
-        return targetB != null ? targetB.copy() : FiguraVec3.of(parseStringData(bCode[0], delta), parseStringData(bCode[1], delta), parseStringData(bCode[2], delta));
+        return targetB != null ? targetB.copy() : FiguraVec3.of(getB(0, delta), getB(1, delta), getB(2, delta));
     }
 
-    private float parseStringData(String data, float delta) {
-        FiguraMod.pushProfiler(data);
+    /**
+     * Get a {@link KeyframeValue} for the provided source and Lua chunk name.
+     *
+     * @param source    source code or double literal
+     * @param chunkName chunk name for debugging in case of errors
+     * @return KeyframeValue if successful, or null if not (usually because the avatar isn't ready yet)
+     */
+    private KeyframeValue compile(String source, String chunkName) {
         try {
-            return FiguraMod.popReturnProfiler(Float.parseFloat(data));
-        } catch (Exception ignored) {
-            if (data == null)
-                return FiguraMod.popReturnProfiler(0f);
-
             try {
-                LuaValue val = owner.loadScript(chunkName, "return " + data);
-                if (val == null)
-                    return FiguraMod.popReturnProfiler(0f);
-
-                Varargs args = owner.run(val, owner.animation, delta, animation);
-                if (args.isnumber(1))
-                    return FiguraMod.popReturnProfiler(args.tofloat(1));
-                else
-                    throw new Exception(); // dummy exception
-            } catch (Exception ignored2) {
+                return KeyframeValue.literal(Double.parseDouble(source));
+            } catch (NumberFormatException fail) {
                 try {
-                    LuaValue val = owner.loadScript(chunkName, data);
-                    if (val == null)
-                        return FiguraMod.popReturnProfiler(0f);
-
-                    Varargs args = owner.run(val, owner.animation, delta, animation);
-                    if (args.isnumber(1))
-                        return FiguraMod.popReturnProfiler(args.tofloat(1));
-                    else
-                        throw new LuaError("Failed to parse data from [" + this.chunkName + "], expected number, but got " + args.arg(1).typename());
-                } catch (Exception e) {
-                    if (owner.luaRuntime != null)
-                        owner.luaRuntime.error(e);
+                    // Okay, so it's Lua. Try as an expression first...
+                    LuaValue chunk = owner.loadScript(chunkName, "return " + source);
+                    if (chunk == null) return null;
+                    return KeyframeValue.function(chunk, chunkName);
+                } catch (LuaError e) { /* chunk compile failed (probably syntax) */
+                    // Try as a statement.
+                    LuaValue chunk = owner.loadScript(chunkName, source);
+                    if (chunk == null) return null;
+                    return KeyframeValue.function(chunk, chunkName);
                 }
             }
+        } catch (Exception e3) {
+            // generic failure
+            if (owner.luaRuntime != null) {
+                owner.luaRuntime.error(e3);
+            }
+            return null;
         }
+    }
 
-        return FiguraMod.popReturnProfiler(0f);
+    private double evaluate(KeyframeValue k, float delta) {
+        if (k.function == null) return k.literal;
+        Varargs v = owner.run(k.function, owner.animation, delta, animation);
+        if (v == null)
+            throw new LuaError(String.format(
+                    "Tried to run animation with code [%s] without a functioning avatar runtime",
+                    k.chunkName
+            ));
+        if (!v.isnumber(1)) throw new LuaError(String.format(
+                "Failed to parse data from [%s]: expected number, but got %s",
+                k.chunkName, v.arg1().typename()
+        ));
+        return v.todouble(1);
+    }
+
+    private double evalCompile(KeyframeValue[] cache, String[] code, int idx, float delta) {
+        try {
+            if (cache[idx] != null) return evaluate(cache[idx], delta);
+            cache[idx] = compile(code[idx], generateChunkName(idx));
+            if (cache[idx] != null) return evaluate(cache[idx], delta);
+            throw new LuaError("Can't compile keyframe [" + generateChunkName(idx) + "] (code: " + code[idx] + ")");
+        } catch (Exception e) {
+            if (owner.luaRuntime != null) {
+                owner.luaRuntime.error(e);
+            }
+            return 0; // fallback
+        }
+    }
+
+    private double getA(int idx, float delta) {
+        return evalCompile(aCache, aCode, idx, delta);
+    }
+
+    private double getB(int idx, float delta) {
+        return evalCompile(bCache, bCode, idx, delta);
+    }
+
+    private String generateChunkName(int idx) {
+        StringBuilder b = new StringBuilder();
+        // note: scripts rely on the animation name followed by "keyframe" being at the start
+        b.append(animation.getName())
+                .append(" keyframe (")
+                .append(time)
+                .append("s, ");
+
+        switch (idx) {
+            case 0: b.append("X"); break;
+            case 1: b.append("Y"); break;
+            case 2: b.append("Z"); break;
+            default: b.append("?"); break;
+        }
+        b.append(")");
+        return b.toString();
     }
 
     public float getTime() {

--- a/common/src/main/java/org/figuramc/figura/animation/Keyframe.java
+++ b/common/src/main/java/org/figuramc/figura/animation/Keyframe.java
@@ -17,17 +17,7 @@ public class Keyframe implements Comparable<Keyframe> {
      * <p>(the presence or absence of {@link KeyframeValue#function} implies which value is the "real" one)</p>
      * <p>{@link KeyframeValue#chunkName} is also stored in here so that we don't have to dig it out of the function</p>
      */
-    public static class KeyframeValue {
-        public final double literal;
-        public final LuaValue function;
-        public final String chunkName;
-
-        private KeyframeValue(double literal, LuaValue function, String chunkName) {
-            this.literal = literal;
-            this.function = function;
-            this.chunkName = chunkName;
-        }
-
+    public record KeyframeValue(double literal, LuaValue function, String chunkName) {
         public static KeyframeValue literal(double literal) {
             return new KeyframeValue(literal, null, null);
         }
@@ -160,10 +150,18 @@ public class Keyframe implements Comparable<Keyframe> {
                 .append("s, ");
 
         switch (idx) {
-            case 0: b.append("X"); break;
-            case 1: b.append("Y"); break;
-            case 2: b.append("Z"); break;
-            default: b.append("?"); break;
+            case 0:
+                b.append("X");
+                break;
+            case 1:
+                b.append("Y");
+                break;
+            case 2:
+                b.append("Z");
+                break;
+            default:
+                b.append("?");
+                break;
         }
         b.append(")");
         return b.toString();


### PR DESCRIPTION
Makes performance even with simple expressions way better because you're not running the Lua parser every frame

[bug-reports thread](https://discord.com/channels/1129805506354085959/1393550441945759774)

also comes with a side of more useful(?) error messages:
- errors in three-component keyframes (rotation, position, scale) now say which component is causing the error (`X`, `Y`, or `Z`); however, the information on _which_ channel or bone is problematic isn't available to the keyframe. ideally that would be there too, but since it's not the main purpose of this PR we've not changed it
- tried to add more useful messages for things going wrong internally (failing to execute entirely, ...)

~~Temporarily draftified: code keyframes broke :pensive:~~ update: Fixed!