### PR TITLE
Made render tasks copyable

### DIFF
--- a/common/src/main/java/org/figuramc/figura/model/FiguraModelPart.java
+++ b/common/src/main/java/org/figuramc/figura/model/FiguraModelPart.java
@@ -1573,6 +1573,7 @@ public class FiguraModelPart implements Comparable<FiguraModelPart> {
         result.parentType = parentType;
         result.textureHeight = textureHeight;
         result.textureWidth = textureWidth;
+        result.renderTasks.putAll(renderTasks);
 
         if (parentType.isSeparate)
             owner.renderer.sortParts();
@@ -1603,6 +1604,7 @@ public class FiguraModelPart implements Comparable<FiguraModelPart> {
         result.parentType = parentType;
         result.textureHeight = textureHeight;
         result.textureWidth = textureWidth;
+        this.renderTasks.forEach((key, value) -> result.renderTasks.put(key, value.copy()));
 
         if (parentType.isSeparate)
             owner.renderer.sortParts();

--- a/common/src/main/java/org/figuramc/figura/model/rendertasks/BlockTask.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendertasks/BlockTask.java
@@ -14,6 +14,7 @@ import org.figuramc.figura.lua.docs.LuaMethodDoc;
 import org.figuramc.figura.lua.docs.LuaMethodOverload;
 import org.figuramc.figura.lua.docs.LuaTypeDoc;
 import org.figuramc.figura.model.FiguraModelPart;
+import org.figuramc.figura.model.PartCustomization;
 import org.figuramc.figura.utils.LuaUtils;
 
 @LuaWhitelist
@@ -84,6 +85,15 @@ public class BlockTask extends RenderTask {
     @LuaWhitelist
     public BlockTask block(Object block) {
         return setBlock(block);
+    }
+
+    @Override
+    public RenderTask copy() {
+        BlockTask copy = new BlockTask(name + "_copy", owner, parent);
+        copy.block = this.block;
+        copy.cachedComplexity = this.cachedComplexity;
+        this.customization.copyTo(copy.customization);
+        return copy;
     }
 
     @Override

--- a/common/src/main/java/org/figuramc/figura/model/rendertasks/EntityTask.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendertasks/EntityTask.java
@@ -163,4 +163,18 @@ public class EntityTask extends RenderTask {
         }
         return this;
     }
+
+    @Override
+    public RenderTask copy() {
+        EntityTask copy = new EntityTask(name + "_copy", owner, parent);
+        assert Minecraft.getInstance().level != null;
+        if(entity != null) {
+            CompoundTag tag = new CompoundTag();
+            entity.save(tag);
+            copy.entity = EntityType.loadEntityRecursive(tag, Minecraft.getInstance().level, Function.identity());
+        }
+        copy.ticksSinceEntity = this.ticksSinceEntity;
+        this.customization.copyTo(copy.customization);
+        return copy;
+    }
 }

--- a/common/src/main/java/org/figuramc/figura/model/rendertasks/ItemTask.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendertasks/ItemTask.java
@@ -132,4 +132,15 @@ public class ItemTask extends RenderTask {
     public ItemStack getItem() {
         return item;
     }
+
+    @Override
+    public RenderTask copy() {
+        ItemTask copy = new ItemTask(name + "_copy", owner, parent);
+        copy.item = this.item.copy();
+        copy.displayMode = this.displayMode;
+        copy.left = this.left;
+        copy.cachedComplexity = this.cachedComplexity;
+        this.customization.copyTo(copy.customization);
+        return copy;
+    }
 }

--- a/common/src/main/java/org/figuramc/figura/model/rendertasks/RenderTask.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendertasks/RenderTask.java
@@ -308,6 +308,12 @@ public abstract class RenderTask {
         return setMatrix(mat);
     }
 
+    @LuaWhitelist
+    @LuaMethodDoc(
+            value = "copy"
+    )
+    public abstract RenderTask copy();
+
     @Override
     public String toString() {
         return name + " (Render Task)";

--- a/common/src/main/java/org/figuramc/figura/model/rendertasks/SpriteTask.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendertasks/SpriteTask.java
@@ -459,6 +459,27 @@ public class SpriteTask extends RenderTask {
     }
 
     @Override
+    public RenderTask copy() {
+        SpriteTask copy = new SpriteTask(name + "_copy", owner, parent);
+        copy.texture = texture;
+        copy.textureW = textureW;
+        copy.textureH = textureH;
+        copy.width = width;
+        copy.height = height;
+        copy.regionW = regionW;
+        copy.regionH = regionH;
+        copy.u = u;
+        copy.v = v;
+        copy.r = r;
+        copy.g = g;
+        copy.b = b;
+        copy.a = a;
+        copy.renderType = renderType;
+        copy.vertices.addAll(vertices);
+        return copy;
+    }
+
+    @Override
     public String toString() {
         return name + " (Sprite Render Task)";
     }

--- a/common/src/main/java/org/figuramc/figura/model/rendertasks/SpriteTask.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendertasks/SpriteTask.java
@@ -475,7 +475,7 @@ public class SpriteTask extends RenderTask {
         copy.b = b;
         copy.a = a;
         copy.renderType = renderType;
-        copy.vertices.addAll(vertices);
+        this.vertices.forEach(v-> copy.vertices.add(v.copy()));
         return copy;
     }
 

--- a/common/src/main/java/org/figuramc/figura/model/rendertasks/TextTask.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendertasks/TextTask.java
@@ -418,6 +418,28 @@ public class TextTask extends RenderTask {
     }
 
     @Override
+    public RenderTask copy() {
+        TextTask copy = new TextTask(this.name + "_copy", this.owner, this.parent);
+        copy.textCached = this.textCached;
+        copy.text = this.text;
+        copy.alignment = this.alignment;
+        copy.shadow = this.shadow;
+        copy.outline = this.outline;
+        copy.outlineColor = this.outlineColor;
+        copy.background = this.background;
+        copy.backgroundColor = this.backgroundColor;
+        copy.seeThrough = this.seeThrough;
+        copy.opacity = this.opacity;
+        copy.width = this.width;
+        copy.wrap = this.wrap;
+        copy.cachedComplexity = this.cachedComplexity;
+        copy.cacheWidth = this.cacheWidth;
+        copy.cacheHeight = this.cacheHeight;
+        this.customization.copyTo(copy.customization);
+        return copy;
+    }
+
+    @Override
     public String toString() {
         return name + " (Text Render Task)";
     }

--- a/common/src/main/java/org/figuramc/figura/utils/LuaUtils.java
+++ b/common/src/main/java/org/figuramc/figura/utils/LuaUtils.java
@@ -245,6 +245,8 @@ public class LuaUtils {
                 throw new LuaError("Could not parse block state from string: " + string);
             }
         }
+        else if (block instanceof BlockState)
+            return (BlockState) block;
 
         throw new LuaError("Illegal argument to " + methodName + "(): " + block);
     }

--- a/common/src/main/resources/assets/figura/lang/en_us.json
+++ b/common/src/main/resources/assets/figura/lang/en_us.json
@@ -1435,6 +1435,7 @@
     "figura.docs.render_task.get_normal_matrix": "Recalculates the normal matrix for this render task, based on its current position, rotation, scale, and pivot, then returns this matrix",
     "figura.docs.render_task.get_normal_matrix_raw": "Returns the normal matrix for this render task\nThe Raw version of the function is different in that it doesn't recalculate the matrix before returning it",
     "figura.docs.render_task.set_matrix": "Sets the given matrix as the position matrix for this render task\nThe normal matrix is automatically calculated as the inverse transpose of this matrix\nCalling this DOES NOT CHANGE the values of position, rot, or scale in the render task\nIf you call setPos() or a similar function, the effects of setMatrix() will be overwritten",
+    "figura.docs.render_task.copy": "Copies this render task and returns a new instance.\nThe new task will copy all properties, but will not be added to any model part and the name will share the same but with \"_copy\" appended to it.",
     "figura.docs.item_task": "A task for rendering an Item",
     "figura.docs.item_task.set_item": "Sets the Item for this task render",
     "figura.docs.item_task.get_display_mode": "Gets this task item display mode",


### PR DESCRIPTION
Render tasks can now be copied by users with renderTask:copy(), calling copy on a ModelPart also copies Tasks on it by reference to match child behavior for parts. But they are copied by value if deepCopy is used. 