### PR TITLE
Fix :getMousePos() for proper correction for High DPI / Retina Mode Displays

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/ClientAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/ClientAPI.java
@@ -252,9 +252,12 @@ public class ClientAPI {
     @LuaWhitelist
     @LuaMethodDoc("client.get_mouse_pos")
     public static FiguraVec2 getMousePos() {
-        MouseHandler mouse = Minecraft.getInstance().mouseHandler;
-        return FiguraVec2.of(mouse.xpos(), mouse.ypos());
-    }
+		MouseHandler mouse = Minecraft.getInstance().mouseHandler;
+		FloatBuffer xScale = BufferUtils.createFloatBuffer(1);
+		FloatBuffer yScale = BufferUtils.createFloatBuffer(1);
+		GLFW.glfwGetWindowContentScale( (long) Minecraft.getInstance().getWindow().getWindow(), xScale, yScale);
+		return FiguraVec2.of(mouse.xpos() * xScale.get(0), mouse.ypos() * yScale.get(0));
+	}
 
     @LuaWhitelist
     @LuaMethodDoc("client.get_scaled_window_size")

--- a/common/src/main/java/org/figuramc/figura/lua/api/ClientAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/ClientAPI.java
@@ -49,6 +49,8 @@ import org.figuramc.figura.utils.*;
 import org.joml.Vector3f;
 import org.luaj.vm2.LuaError;
 import org.luaj.vm2.LuaValue;
+import org.lwjgl.BufferUtils;
+import org.lwjgl.glfw.GLFW;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;

--- a/common/src/main/java/org/figuramc/figura/lua/api/ClientAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/ClientAPI.java
@@ -55,6 +55,7 @@ import org.lwjgl.glfw.GLFW;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.FloatBuffer;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.function.Supplier;


### PR DESCRIPTION
as said, modifies the :getMousePos() position by the contentScaleFactor

```java
@LuaWhitelist
	@LuaMethodDoc("client.get_mouse_pos")
	public static FiguraVec2 getMousePos() {
		MouseHandler mouse = Minecraft.getInstance().mouseHandler;
		FloatBuffer xScale = BufferUtils.createFloatBuffer(1);
		FloatBuffer yScale = BufferUtils.createFloatBuffer(1);
		GLFW.glfwGetWindowContentScale( (long) Minecraft.getInstance().getWindow().getWindow(), xScale, yScale);
		return FiguraVec2.of(mouse.xpos() * xScale.get(0), mouse.ypos() * yScale.get(0));
	}
```

_post patch version of my extura fork with this fix, also works w/ res change_
![tiv 2025-09-11 @ java](https://github.com/user-attachments/assets/f68ebb4d-d5b7-4537-9fdd-180d322bb94a)
