### PR TITLE
PRE_RENDER patches

### DIFF
--- a/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
+++ b/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
@@ -293,8 +293,11 @@ public class Avatar {
         if (scriptError || luaRuntime == null || !loaded)
             return;
 
-        // render.reset(permissions.get(Permissions.RENDER_INST));
-        // Moved to GameRenderMixin for preRender
+        // Instruction count resetting happens in GameRenderMixin with pre_render event
+        // If there isn't an entity loaded, that event never runs. Fallback to resetting instruction count here
+        if (luaRuntime.getUser() == null)
+            render.reset(permissions.get(Permissions.RENDER_INST));
+            
         worldRender.reset(permissions.get(Permissions.WORLD_RENDER_INST));
         run("WORLD_RENDER", worldRender, delta);
     }

--- a/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
+++ b/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
@@ -294,7 +294,7 @@ public class Avatar {
             return;
 
         // render.reset(permissions.get(Permissions.RENDER_INST));
-		// Moved to GameRenderMixin for preRender
+        // Moved to GameRenderMixin for preRender
         worldRender.reset(permissions.get(Permissions.WORLD_RENDER_INST));
         run("WORLD_RENDER", worldRender, delta);
     }
@@ -393,10 +393,10 @@ public class Avatar {
         run("POST_WORLD_RENDER", worldRender.post(), delta);
     }
 
-	public void preRenderEvent(float delta) {
-		if (loaded && luaRuntime != null && luaRuntime.getUser() != null)
-			run("PRE_RENDER", render, delta, renderMode.name());
-	}
+    public void preRenderEvent(float delta) {
+        if (loaded && luaRuntime != null && luaRuntime.getUser() != null)
+            run("PRE_RENDER", render, delta, renderMode.name());
+    }
 
     public boolean skullRenderEvent(float delta, BlockStateAPI block, ItemStackAPI item, EntityAPI<?> entity, String mode) {
         Varargs result = null;

--- a/common/src/main/java/org/figuramc/figura/lua/api/event/EventsAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/event/EventsAPI.java
@@ -92,7 +92,7 @@ public class EventsAPI {
     public final LuaEvent TOTEM = new LuaEvent();
     @LuaFieldDoc("events.damage")
     public final LuaEvent DAMAGE = new LuaEvent();
-	@LuaFieldDoc("events.pre_render")
+    @LuaFieldDoc("events.pre_render")
     public final LuaEvent PRE_RENDER = new LuaEvent();
 
     private final Map<String, LuaEvent> events = new HashMap<>();
@@ -121,7 +121,7 @@ public class EventsAPI {
         events.put("RESOURCE_RELOAD", RESOURCE_RELOAD);
         events.put("TOTEM", TOTEM);
         events.put("DAMAGE", DAMAGE);
-		events.put("PRE_RENDER", PRE_RENDER);
+        events.put("PRE_RENDER", PRE_RENDER);
 
         for (FiguraEvent entrypoint : ENTRYPOINTS) {
             String ID = entrypoint.getID().toUpperCase(Locale.US);

--- a/common/src/main/java/org/figuramc/figura/mixin/render/GameRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/GameRendererMixin.java
@@ -10,7 +10,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import org.figuramc.figura.FiguraMod;
 import org.figuramc.figura.avatar.Avatar;
-import org.figuramc.figura.avatar.Avatar.Instructions;
 import org.figuramc.figura.avatar.AvatarManager;
 import org.figuramc.figura.ducks.GameRendererAccessor;
 import org.figuramc.figura.lua.api.ClientAPI;
@@ -180,12 +179,14 @@ public abstract class GameRendererMixin implements GameRendererAccessor {
     public double figura$getFov(Camera camera, float tickDelta, boolean changingFov) {
         return this.getFov(camera, tickDelta, changingFov);
     }
-	@Inject(method = "render", at = @At("HEAD"))
-	private void preRender(float tickDelta, long startTime, boolean tick, CallbackInfo ci) {
-		Avatar avatar = AvatarManager.getAvatar(this.minecraft.getCameraEntity());
-		if (avatar == null) return;
-		avatar.render.reset(avatar.permissions.get(Permissions.RENDER_INST));
+    
+    @Inject(method = "render", at = @At("HEAD"))
+    private void preRender(float tickDelta, long startTime, boolean tick, CallbackInfo ci) {
+        Avatar avatar = AvatarManager.getAvatar(this.minecraft.getCameraEntity());
+        if (avatar == null)
+            return;
+        avatar.render.reset(avatar.permissions.get(Permissions.RENDER_INST));
 
-		AvatarManager.executeAll("preRender", renderedAvatar -> renderedAvatar.preRenderEvent(tickDelta));
-	}
+        AvatarManager.executeAll("preRender", renderedAvatar -> renderedAvatar.preRenderEvent(tickDelta));
+    }
 }

--- a/common/src/main/resources/assets/figura/lang/en_us.json
+++ b/common/src/main/resources/assets/figura/lang/en_us.json
@@ -1113,7 +1113,7 @@
     "figura.docs.events.totem": "Called whenever you use a Totem of Undying to cheat death\nIf returned true the animation is cancelled",
     "figura.docs.events.damage": "Called every time you take damage\nTakes four arguments: the damage type as a string, the entity that dealt the damage, the attacking entity, and the damage position\\nThe last three arguments may return nil if there is no direct damage source",
     "figura.docs.events.pre_render": "Runs at the HEAD of Minecraft's render function\nArgument 1 is a number between 0 to 1 for the delta between last tick and the next tick\nArgument 2 is a string with the name of the source of this render event (See /figura docs enums render_modes)",
-	"figura.docs.events.get_events": "Returns a table with all events types",
+    "figura.docs.events.get_events": "Returns a table with all events types",
     "figura.docs.event": "A hook for a certain event in Minecraft\nYou may register functions to one, and those functions will be called when the event occurs",
     "figura.docs.event.register": "Register a function on this event\nFunctions are run in registration order\nAn optional string argument can be given, grouping functions under that name, for an easier management later on",
     "figura.docs.event.clear": "Clears the given event of all its functions",


### PR DESCRIPTION
This PR fixes indentation in some code, and the instruction counter not resetting when the avatar entity is unloaded