### PR TITLE
qol: treat .jars as .zip avatars

### DIFF
--- a/common/src/main/java/org/figuramc/figura/avatar/local/LocalAvatarFetcher.java
+++ b/common/src/main/java/org/figuramc/figura/avatar/local/LocalAvatarFetcher.java
@@ -379,7 +379,7 @@ public class LocalAvatarFetcher {
                         children.add(folder);
                         found = true;
                     }
-                } else if (IOUtils.getFileNameOrEmpty(path).endsWith(".zip")) {
+                } else if (IOUtils.getFileNameOrEmpty(path).endsWith(".zip") || IOUtils.getFileNameOrEmpty(path).endsWith(".jar")) {
                     try {
                         FileSystem opened = FileSystems.newFileSystem(path);
                         if ("jar".equalsIgnoreCase(opened.provider().getScheme())) {


### PR DESCRIPTION
allows loading an avatar from a .jar, useful for e.g. bundling an avatar with a mod implementing server-side features for it

literally just changes the `*.zip` check to check for `*.zip || *.jar`
