### PR TITLE
feat: TextTask line spacing

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/ClientAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/ClientAPI.java
@@ -312,14 +312,16 @@ public class ClientAPI {
 
     @LuaWhitelist
     @LuaMethodDoc(
-            overloads = @LuaMethodOverload(
-                    argumentTypes = String.class,
-                    argumentNames = "text"
-            ),
+            overloads = {
+                @LuaMethodOverload(
+                    argumentTypes = {String.class, Integer.class},
+                    argumentNames = {"text", "lineSpacing"}
+                )
+            },
             value = "client.get_text_height"
     )
-    public static int getTextHeight(String text) {
-        return TextUtils.getHeight(TextUtils.splitText(TextUtils.tryParseJson(text), "\n"), Minecraft.getInstance().font);
+    public static int getTextHeight(String text, int lineSpacing) {
+        return TextUtils.getHeight(TextUtils.splitText(TextUtils.tryParseJson(text), "\n"), Minecraft.getInstance().font, lineSpacing);
     }
 
     @LuaWhitelist
@@ -330,18 +332,18 @@ public class ClientAPI {
                             argumentNames = "text"
                     ),
                     @LuaMethodOverload(
-                            argumentTypes = {String.class, Integer.class, Boolean.class},
-                            argumentNames = {"text", "maxWidth", "wrap"}
+                            argumentTypes = {String.class, Integer.class, Boolean.class, Integer.class},
+                            argumentNames = {"text", "maxWidth", "wrap", "lineSpacing"}
                     )
             },
             value = "client.get_text_dimensions"
     )
-    public static FiguraVec2 getTextDimensions(@LuaNotNil String text, int maxWidth, Boolean wrap) {
+    public static FiguraVec2 getTextDimensions(@LuaNotNil String text, int maxWidth, Boolean wrap, int lineSpacing) {
         Component component = TextUtils.tryParseJson(text);
         Font font = Minecraft.getInstance().font;
         List<Component> list = TextUtils.formatInBounds(component, font, maxWidth, wrap == null || wrap);
         int x = TextUtils.getWidth(list, font);
-        int y = TextUtils.getHeight(list, font);
+        int y = TextUtils.getHeight(list, font, lineSpacing);
         return FiguraVec2.of(x, y);
     }
 

--- a/common/src/main/java/org/figuramc/figura/model/rendertasks/TextTask.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendertasks/TextTask.java
@@ -44,6 +44,7 @@ public class TextTask extends RenderTask {
     private int opacity = 0xFF;
     private int width = 0;
     private boolean wrap = true;
+    private int lineSpace = 1;
 
     private int cachedComplexity, cacheWidth, cacheHeight;
 
@@ -81,7 +82,7 @@ public class TextTask extends RenderTask {
         }
 
         // text
-        for (int i = 0, j = 0; i < text.size(); i++, j += (font.lineHeight + 1)) {
+        for (int i = 0, j = 0; i < text.size(); i++, j += (font.lineHeight + this.lineSpace)) {
             Component text = this.text.get(i);
             int x = -alignment.apply(font, text);
 
@@ -120,7 +121,7 @@ public class TextTask extends RenderTask {
 
         Font font = Minecraft.getInstance().font;
         cacheWidth = TextUtils.getWidth(this.text, font);
-        cacheHeight = TextUtils.getHeight(this.text, font);
+        cacheHeight = TextUtils.getHeight(this.text, font, this.lineSpace);
     }
 
 
@@ -442,5 +443,27 @@ public class TextTask extends RenderTask {
     @Override
     public String toString() {
         return name + " (Text Render Task)";
+    }
+
+    // Internally, the line spacing will be 1 less than what's returned to the user. This is because in reality, a spacing of 1 is 2 pixels.
+    // This is so the user can set the spacing to 0 to make multiple lines of emojis sit flush
+
+    @LuaWhitelist
+    @LuaMethodDoc("text_task.get_spacing")
+    public float getSpacing() {
+        return this.lineSpace + 1;
+    }
+
+    @LuaWhitelist
+    @LuaMethodDoc(overloads = @LuaMethodOverload(argumentTypes = Integer.class, argumentNames = "spacing"), aliases = "lineSpacing", value = "text_task.set_spacing")
+    public TextTask setSpacing(int spacing) {
+        this.lineSpace = spacing - 1;
+        updateText();
+        return this;
+    }
+
+    @LuaWhitelist
+    public TextTask spacing(int spacing) {
+        return setSpacing(spacing);
     }
 }

--- a/common/src/main/java/org/figuramc/figura/utils/TextUtils.java
+++ b/common/src/main/java/org/figuramc/figura/utils/TextUtils.java
@@ -196,14 +196,10 @@ public class TextUtils {
         return width;
     }
 
-    // correctly calculates the height of a list of text componennts
-    public static int getHeight(List<?> text, Font font, int lineSpaceing) {
+    // correctly calculates the height of a list of text components
+    public static int getHeight(List<?> text, Font font, int lineSpacing) {
         int lines = text.size();
-        return (lines * font.lineHeight) + Math.max((lines-1)*lineSpaceing, 0);
-    }
-
-    public static int getHeight(List<?> text, Font font) {
-        return getHeight(text, font, 1);
+        return (lines * font.lineHeight) + (lines - 1) * lineSpacing;
     }
 
     public static Component replaceStyle(FormattedText text, Style newStyle, Predicate<Style> predicate) {


### PR DESCRIPTION
# Changes:
* Added setting the line spacing to TextTasks using `spacing`/`setSpacing` methods (Defaults to 2)
* Added passing text line spacing into `getTextHeight`, and `getTextDimensions` functions

# Why?

Emojis exist and there's no way to decrease the spacing between lines of emojis to make them flush without additional code. Figura already handles splitting text inside TextTasks so it'd make sense for Figura to also allow for setting the spacing.

<img width="627" height="679" alt="image" src="https://github.com/user-attachments/assets/03bcebd6-7ddb-4e0b-b5d0-a6f9da373274" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0e1a3b1a-ae77-4f9d-a554-e2dd07a4d8f9" />
