### PR TITLE
Placeholders for TextTasks

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/ClientAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/ClientAPI.java
@@ -320,8 +320,8 @@ public class ClientAPI {
             },
             value = "client.get_text_height"
     )
-    public static int getTextHeight(String text, int lineSpacing) {
-        return TextUtils.getHeight(TextUtils.splitText(TextUtils.tryParseJson(text), "\n"), Minecraft.getInstance().font, lineSpacing);
+    public static int getTextHeight(String text, Integer lineSpacing) {
+        return TextUtils.getHeight(TextUtils.splitText(TextUtils.tryParseJson(text), "\n"), Minecraft.getInstance().font, (lineSpacing == null ? 1 : lineSpacing));
     }
 
     @LuaWhitelist
@@ -338,12 +338,12 @@ public class ClientAPI {
             },
             value = "client.get_text_dimensions"
     )
-    public static FiguraVec2 getTextDimensions(@LuaNotNil String text, int maxWidth, Boolean wrap, int lineSpacing) {
+    public static FiguraVec2 getTextDimensions(@LuaNotNil String text, int maxWidth, Boolean wrap, Integer lineSpacing) {
         Component component = TextUtils.tryParseJson(text);
         Font font = Minecraft.getInstance().font;
         List<Component> list = TextUtils.formatInBounds(component, font, maxWidth, wrap == null || wrap);
         int x = TextUtils.getWidth(list, font);
-        int y = TextUtils.getHeight(list, font, lineSpacing);
+        int y = TextUtils.getHeight(list, font, (lineSpacing == null ? 1 : lineSpacing));
         return FiguraVec2.of(x, y);
     }
 

--- a/common/src/main/java/org/figuramc/figura/model/rendertasks/TextTask.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendertasks/TextTask.java
@@ -114,7 +114,7 @@ public class TextTask extends RenderTask {
 
         Component component = TextUtils.tryParseJson(this.textCached);
         component = Badges.noBadges4U(component);
-        component = Badges.appendBadges(component, this.owner.owner, (this.textCached.contains("${badges}") || this.textCached.contains("${segdab}")));
+        component = Badges.appendBadges(component, this.owner.owner, Badges.hasCustomBadges(component));
         component = Emojis.applyEmojis(component);
         component = Emojis.removeBlacklistedEmojis(component);
         component = TextUtils.replaceInText(component, "\\$\\{name\\}", this.owner.entityName);

--- a/common/src/main/java/org/figuramc/figura/model/rendertasks/TextTask.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendertasks/TextTask.java
@@ -452,19 +452,16 @@ public class TextTask extends RenderTask {
         return name + " (Text Render Task)";
     }
 
-    // Internally, the line spacing will be 1 less than what's returned to the user. This is because in reality, a spacing of 1 is 2 pixels.
-    // This is so the user can set the spacing to 0 to make multiple lines of emojis sit flush
-
     @LuaWhitelist
     @LuaMethodDoc("text_task.get_spacing")
     public float getSpacing() {
-        return this.lineSpace + 1;
+        return this.lineSpace;
     }
 
     @LuaWhitelist
     @LuaMethodDoc(overloads = @LuaMethodOverload(argumentTypes = Integer.class, argumentNames = "spacing"), aliases = "lineSpacing", value = "text_task.set_spacing")
     public TextTask setSpacing(int spacing) {
-        this.lineSpace = spacing - 1;
+        this.lineSpace = spacing;
         updateText();
         return this;
     }

--- a/common/src/main/java/org/figuramc/figura/model/rendertasks/TextTask.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendertasks/TextTask.java
@@ -45,6 +45,7 @@ public class TextTask extends RenderTask {
     private int width = 0;
     private boolean wrap = true;
     private int lineSpace = 1;
+    private boolean hasBadges;
 
     private int cachedComplexity, cacheWidth, cacheHeight;
 
@@ -68,6 +69,10 @@ public class TextTask extends RenderTask {
         int op = opacity << 24 | 0xFFFFFF;
         Font.DisplayMode displayMode = seeThrough ? Font.DisplayMode.SEE_THROUGH : Font.DisplayMode.POLYGON_OFFSET;
         float vertexOffset = outline ? FiguraMod.VERTEX_OFFSET : 0f;
+
+        // badges
+        if (this.hasBadges)
+            updateText();
 
         // background
         if (bg != 0) {
@@ -114,7 +119,8 @@ public class TextTask extends RenderTask {
 
         Component component = TextUtils.tryParseJson(this.textCached);
         component = Badges.noBadges4U(component);
-        component = Badges.appendBadges(component, this.owner.owner, Badges.hasCustomBadges(component));
+        this.hasBadges = Badges.hasCustomBadges(component);
+        component = Badges.appendBadges(component, this.owner.owner, this.hasBadges);
         component = Emojis.applyEmojis(component);
         component = Emojis.removeBlacklistedEmojis(component);
         component = TextUtils.replaceInText(component, "\\$\\{name\\}", this.owner.entityName);

--- a/common/src/main/java/org/figuramc/figura/model/rendertasks/TextTask.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendertasks/TextTask.java
@@ -117,6 +117,7 @@ public class TextTask extends RenderTask {
         component = Badges.appendBadges(component, this.owner.owner, (this.textCached.contains("${badges}") || this.textCached.contains("${segdab}")));
         component = Emojis.applyEmojis(component);
         component = Emojis.removeBlacklistedEmojis(component);
+        component = TextUtils.replaceInText(component, "\\$\\{name\\}", this.owner.entityName);
         this.text = TextUtils.formatInBounds(component, Minecraft.getInstance().font, width, wrap);
 
         Font font = Minecraft.getInstance().font;


### PR DESCRIPTION
* Fixed the ${badges} placeholder so that it'd show dynamic badges
* Added ${name} placeholder to TextTasks
* Fixed `getTextHeight` and `getTextDimensions` functions
* Rolled back lineSpacing being different between Java and Lua side to avoid confusion