### PR TITLE
Remove networking port restrictions

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/net/NetworkingAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/net/NetworkingAPI.java
@@ -91,9 +91,6 @@ public class NetworkingAPI {
         ArrayList<Filter> filters = Configs.NETWORK_FILTER.getFilters();
         try {
             URL url = new URL(link);
-            if (url.getPort() != -1 && url.getPort() != 80 && url.getPort() != 443)
-                throw new LuaError("Port %s not allowed, only 80 (HTTP) and 443 (HTTPS) are permitted.".formatted(url.getPort()));
-
             return switch (level) {
                 case WHITELIST -> filters.stream().anyMatch(f -> f.matches(url.getHost()));
                 case BLACKLIST -> filters.stream().noneMatch(f -> f.matches(url.getHost()));


### PR DESCRIPTION
why do these exist, again? they make it so much more annoying to work with local services because binding to low ports is a privileged operation, and you can only use two of them (??)

feel free to tell me if this is a horrible take

<sub>we're really running with the tiny PRs lately aren't we?</sub>