### PR TITLE
Use FSB for fetching users more often

### DIFF
--- a/common/src/main/java/org/figuramc/figura/backend2/NetworkStuff.java
+++ b/common/src/main/java/org/figuramc/figura/backend2/NetworkStuff.java
@@ -323,8 +323,7 @@ public class NetworkStuff {
     }
 
     public static void getUser(UserData user) {
-        boolean fetchUser = fsb().isPlayerConnected(user.id) || FiguraMod.isOffline(user.id);
-        if (fsb().connected() && fetchUser) {
+        if (fsb().connected()) {
             fsb().getUserAndApply(user);
             return;
         }


### PR DESCRIPTION
this is mostly for equipping carpet bots, but the previous code exposed some weird behaviour where connecting with a non-FSB client would prevent anyone else from seeing your FSB equipped avatar

now, if FSB is connected, it tries to use that all the time