### PR TITLE
fix circular dependency of docs, configs, and keybinds

### DIFF
--- a/common/src/main/java/org/figuramc/figura/ducks/FiguraKeyStorage.java
+++ b/common/src/main/java/org/figuramc/figura/ducks/FiguraKeyStorage.java
@@ -1,0 +1,17 @@
+package org.figuramc.figura.ducks;
+
+import org.figuramc.figura.config.Configs;
+import org.figuramc.figura.lua.docs.FiguraListDocs;
+import org.figuramc.figura.mixin.input.InputConstantsTypeMixin;
+
+import java.util.LinkedHashSet;
+
+/**
+ * Prevents a nasty circular dependency between {@link InputConstantsTypeMixin}, {@link FiguraListDocs},
+ * and {@link Configs}.
+ */
+public class FiguraKeyStorage {
+    private FiguraKeyStorage() {}
+
+    public static final LinkedHashSet<String> allKeys = new LinkedHashSet<>();
+}

--- a/common/src/main/java/org/figuramc/figura/lua/docs/FiguraListDocs.java
+++ b/common/src/main/java/org/figuramc/figura/lua/docs/FiguraListDocs.java
@@ -21,6 +21,7 @@ import net.minecraft.world.level.levelgen.Heightmap;
 import org.figuramc.figura.FiguraMod;
 import org.figuramc.figura.animation.Animation;
 import org.figuramc.figura.config.Configs;
+import org.figuramc.figura.ducks.FiguraKeyStorage;
 import org.figuramc.figura.mixin.input.KeyMappingAccessor;
 import org.figuramc.figura.mixin.render.GameRendererAccessor;
 import org.figuramc.figura.model.ParentType;
@@ -42,7 +43,7 @@ public class FiguraListDocs {
 
     // -- types --// 
 
-    public static final LinkedHashSet<String> KEYBINDS = new LinkedHashSet<>();
+    public static final LinkedHashSet<String> KEYBINDS = FiguraKeyStorage.allKeys;
     private static final LinkedHashMap<String, List<String>> PARENT_TYPES = new LinkedHashMap<>() {{
         for (ParentType value : ParentType.values())
             put(value.name(), Arrays.asList(value.aliases));

--- a/common/src/main/java/org/figuramc/figura/mixin/input/InputConstantsTypeMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/input/InputConstantsTypeMixin.java
@@ -1,17 +1,18 @@
 package org.figuramc.figura.mixin.input;
 
 import com.mojang.blaze3d.platform.InputConstants;
-import org.figuramc.figura.lua.docs.FiguraListDocs;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static org.figuramc.figura.ducks.FiguraKeyStorage.allKeys;
 
 @Mixin(InputConstants.Type.class)
 public class InputConstantsTypeMixin {
 
     @Inject(at = @At("HEAD"), method = "addKey")
     private static void addKey(InputConstants.Type type, String translationKey, int keyCode, CallbackInfo ci) {
-        FiguraListDocs.KEYBINDS.add(translationKey);
+        allKeys.add(translationKey);
     }
 }


### PR DESCRIPTION
https://discord.com/channels/1129805506354085959/1129815148190761081/1417316245560365096

`InputConstants$Type::addKey` mixin -> `FiguraListDocs` -> `Configs` -> `ConfigType$KeyboardConfig` -> `InputConstants$Key.getKey` (populated by `InputConstants$Type::addKey`)

conflicts with #422