### PR TITLE
Remove PRE_RENDER render context

### DIFF
--- a/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
+++ b/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
@@ -396,7 +396,7 @@ public class Avatar {
 
     public void preRenderEvent(float delta) {
         if (loaded && luaRuntime != null && luaRuntime.getUser() != null)
-            run("PRE_RENDER", preRender, delta, "RENDER");
+            run("PRE_RENDER", preRender, delta);
     }
 
     public boolean skullRenderEvent(float delta, BlockStateAPI block, ItemStackAPI item, EntityAPI<?> entity, String mode) {

--- a/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
+++ b/common/src/main/java/org/figuramc/figura/avatar/Avatar.java
@@ -396,7 +396,7 @@ public class Avatar {
 
     public void preRenderEvent(float delta) {
         if (loaded && luaRuntime != null && luaRuntime.getUser() != null)
-            run("PRE_RENDER", preRender, delta, renderMode.name());
+            run("PRE_RENDER", preRender, delta, "RENDER");
     }
 
     public boolean skullRenderEvent(float delta, BlockStateAPI block, ItemStackAPI item, EntityAPI<?> entity, String mode) {


### PR DESCRIPTION
The pre_render context does not change. It runs once per frame and world_render doesn't pass a render context so it makes sense to not have a render context for pre_render.

The current issue this solves is pre_render currently returns "OTHER" as its context (provided by Avatar.json `renderMode.name()`), when in reality it should have returned "RENDER", though having a constant context doesn't make sense either.