### PR TITLE
fix: RenderTask light and overlay

### DIFF
--- a/common/src/main/java/org/figuramc/figura/model/rendering/ImmediateAvatarRenderer.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendering/ImmediateAvatarRenderer.java
@@ -342,7 +342,7 @@ public class ImmediateAvatarRenderer extends AvatarRenderer {
                 // fix pivots
                 FiguraMod.pushProfiler("fixMatricesPivot");
 
-                // Store calculated light level and parent overlay before pushing pose stack
+                // Store calculated light level and current overlay effect before pushing pose stack
                 PartCustomization oldPeek = customizationStack.peek();
                 int light = oldPeek.light;
                 int overlay = oldPeek.overlay;

--- a/common/src/main/java/org/figuramc/figura/model/rendering/ImmediateAvatarRenderer.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendering/ImmediateAvatarRenderer.java
@@ -343,8 +343,9 @@ public class ImmediateAvatarRenderer extends AvatarRenderer {
                 FiguraMod.pushProfiler("fixMatricesPivot");
 
                 // Store calculated light level and parent overlay before pushing pose stack
-                int light = customizationStack.peek().light;
-                int overlay = customizationStack.peek().overlay;
+                PartCustomization oldPeek = customizationStack.peek();
+                int light = oldPeek.light;
+                int overlay = oldPeek.overlay;
 
                 FiguraVec3 pivot = custom.getPivot().copy().add(custom.getOffsetPivot());
                 pivotOffsetter.setPos(pivot);

--- a/common/src/main/java/org/figuramc/figura/model/rendering/ImmediateAvatarRenderer.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendering/ImmediateAvatarRenderer.java
@@ -342,6 +342,10 @@ public class ImmediateAvatarRenderer extends AvatarRenderer {
                 // fix pivots
                 FiguraMod.pushProfiler("fixMatricesPivot");
 
+                // Store calculated light level and parent overlay before pushing pose stack
+                int light = customizationStack.peek().light;
+                int overlay = customizationStack.peek().overlay;
+
                 FiguraVec3 pivot = custom.getPivot().copy().add(custom.getOffsetPivot());
                 pivotOffsetter.setPos(pivot);
                 pivotOffsetter.recalculate();
@@ -358,8 +362,6 @@ public class ImmediateAvatarRenderer extends AvatarRenderer {
                 // render tasks
                 if (renderTasks) {
                     FiguraMod.popPushProfiler("renderTasks");
-                    int light = peek.light;
-                    int overlay = peek.overlay;
                     interceptRendersIntoFigura = false;
                     for (RenderTask task : part.renderTasks.values()) {
                         if (!task.shouldRender())


### PR DESCRIPTION
Fixes render tasks taking the light level and overlay of another avatar if they don't set their own