### PR TITLE
revert #404 in exchange for :getWindowSize() fix

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/ClientAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/ClientAPI.java
@@ -235,10 +235,20 @@ public class ClientAPI {
     }
 
     @LuaWhitelist
-    @LuaMethodDoc("client.get_window_size")
-    public static FiguraVec2 getWindowSize() {
+    @LuaMethodDoc(
+            overloads = @LuaMethodOverload(
+                    argumentTypes = Boolean.class,
+                    argumentNames = "originalSize"
+            ),
+            value = "client.get_window_size"
+    )
+    public static FiguraVec2 getWindowSize(Boolean originalSize) {
         Window window = Minecraft.getInstance().getWindow();
-        return FiguraVec2.of(window.getWidth(), window.getHeight());
+        if (Boolean.TRUE.equals(originalSize)) {
+            return FiguraVec2.of(window.getWidth(), window.getWidth());
+        } else {
+            return FiguraVec2.of(window.getScreenWidth(), window.getScreenHeight());
+        }
     }
 
     @LuaWhitelist
@@ -256,12 +266,9 @@ public class ClientAPI {
     @LuaWhitelist
     @LuaMethodDoc("client.get_mouse_pos")
     public static FiguraVec2 getMousePos() {
-		MouseHandler mouse = Minecraft.getInstance().mouseHandler;
-		FloatBuffer xScale = BufferUtils.createFloatBuffer(1);
-		FloatBuffer yScale = BufferUtils.createFloatBuffer(1);
-		GLFW.glfwGetWindowContentScale( (long) Minecraft.getInstance().getWindow().getWindow(), xScale, yScale);
-		return FiguraVec2.of(mouse.xpos() * xScale.get(0), mouse.ypos() * yScale.get(0));
-	}
+        MouseHandler mouse = Minecraft.getInstance().mouseHandler;
+        return FiguraVec2.of(mouse.xpos(), mouse.ypos());
+    }
 
     @LuaWhitelist
     @LuaMethodDoc("client.get_scaled_window_size")

--- a/common/src/main/resources/assets/figura/lang/en_us.json
+++ b/common/src/main/resources/assets/figura/lang/en_us.json
@@ -952,7 +952,7 @@
     "figura.docs.client.get_window_size": "Returns the size of the Minecraft window in pixels, as {width, height}",
     "figura.docs.client.get_fov": "Returns the current FOV option of the client, not including additional effects such as speed or sprinting",
     "figura.docs.client.get_system_time": "Returns the current system time in milliseconds",
-    "figura.docs.client.get_mouse_pos": "Returns the position of the mouse in pixels, relative to the top-left corner",
+    "figura.docs.client.get_mouse_pos": "Returns the position of the mouse in pixels, relative to the top-left corner.\nTo properly scale in GUIs, use (* client.getScaledWindowSize() / client.getWindowSize()) over (/ client.getGuiScale()).",
     "figura.docs.client.get_scaled_window_size": "Returns the size of the window in Minecraft's internal GUI units",
     "figura.docs.client.get_gui_scale": "Returns the current value of your Gui Scale setting\nIf you use auto, then it gets the actual current scale",
     "figura.docs.client.get_camera_pos": "Returns the position of the viewer's camera",


### PR DESCRIPTION
OKAY SO with the help of @auriafoxgirl 
we discovered that the mousePos fix actually ends up breaking alot of popular ui libs _(like panels)_, and it's just more efficent to return the proper window size over the corrected mouse pos

_also i just noticed the extura text ignore that_

---
1. this ended up fixing a few things, such as QDAA's scaling being made possible as it relies on the same ui tactics as figura and minecraft itself

<img width="1344" height="649" alt="image" src="https://github.com/user-attachments/assets/40fabf11-f5ba-4ee4-9b63-35fd6d4573e0" />
<center><i>(this is with my new version, original + my bug fix in #404)</i></center>

---
2. also we added a note to i think :getMousePos() in docs to explain proper ui scaling because we thought it'd be useful
<img width="658" height="257" alt="tiv@30-09-2025- DiscordCanary #Yaffle" src="https://github.com/user-attachments/assets/b2dbfe1d-038e-47e3-ae95-fd1c46b1bd0c" />

---
3. `:getWindowSize()` now has an optional parameter to return the original result, in case of anything legacy or anyone in specific relying on the original window size for their mouse detection and what not, it's just `:getWindowSize(true)` 
<img width="665" height="222" alt="tiv@30-09-2025- DiscordCanary #Alligatorgar" src="https://github.com/user-attachments/assets/5cf9ac93-f75c-4904-add5-3f15bd31899a" />
