### PR TITLE
Adds the ability to color emojis through a hex code suffix

### DIFF
--- a/common/src/main/java/org/figuramc/figura/font/EmojiContainer.java
+++ b/common/src/main/java/org/figuramc/figura/font/EmojiContainer.java
@@ -31,6 +31,7 @@ public class EmojiContainer {
 
     private static final String ERROR_MSG = "Invalid emoji metadata \"{}\" @ \"{}\", Reason: Field '{}' {}";
 
+    private static final Style STYLE = Style.EMPTY.withColor(ChatFormatting.WHITE);
 
     public final String name;
     private final ResourceLocation font;
@@ -124,11 +125,12 @@ public class EmojiContainer {
         EmojiMetadata metadata = lookup.getMetadata(unicode.codePointAt(0));
         return makeComponent(metadata, unicode, hover, style).withStyle(
                 Style.EMPTY.withClickEvent(
-                    new ClickEvent(
-                        ClickEvent.Action.COPY_TO_CLIPBOARD,
-                        ":"+key+":"
+                        new ClickEvent(
+                                ClickEvent.Action.COPY_TO_CLIPBOARD,
+                                ":"+key+":"
+                        )
                 )
-        ).withColor(style.getColor()));
+        );
     }
 
     public MutableComponent getShortcutComponent(String shortcut, Style style) {
@@ -139,8 +141,12 @@ public class EmojiContainer {
     }
 
     private MutableComponent makeComponent(@Nullable EmojiMetadata metadata, String unicode, MutableComponent hover, Style style) {
-        style = style.withBold(false).withItalic(false).withObfuscated(false).withUnderlined(false);
-        return Component.literal(unicode).withStyle(style.withFont(font).withHoverEvent(
+        Style styleToUse = metadata != null && metadata.canBeColored ? style.withBold(false).withItalic(false).withObfuscated(false).withUnderlined(false) : STYLE;
+        if (metadata != null && metadata.canBeColored && styleToUse.getColor() == null) {
+            styleToUse = styleToUse.withColor(metadata.defaultColor);
+        }
+
+        return Component.literal(unicode).withStyle(styleToUse.withFont(font).withHoverEvent(
                 new HoverEvent(HoverEvent.Action.SHOW_TEXT, hover
                         .append("\n")
                         .append(FiguraText.of("emoji." + name).withStyle(ChatFormatting.DARK_GRAY)))

--- a/common/src/main/java/org/figuramc/figura/font/EmojiContainer.java
+++ b/common/src/main/java/org/figuramc/figura/font/EmojiContainer.java
@@ -123,8 +123,9 @@ public class EmojiContainer {
             return null;
         }
         EmojiMetadata metadata = lookup.getMetadata(unicode.codePointAt(0));
-        return makeComponent(metadata, unicode, hover, style).withStyle(Style.EMPTY.withClickEvent(
-                new ClickEvent(
+        return makeComponent(metadata, unicode, hover, style).withStyle(
+                Style.EMPTY.withClickEvent(
+                    new ClickEvent(
                         ClickEvent.Action.COPY_TO_CLIPBOARD,
                         ":"+key+":"
                 )

--- a/common/src/main/java/org/figuramc/figura/font/EmojiContainer.java
+++ b/common/src/main/java/org/figuramc/figura/font/EmojiContainer.java
@@ -123,14 +123,12 @@ public class EmojiContainer {
             return null;
         }
         EmojiMetadata metadata = lookup.getMetadata(unicode.codePointAt(0));
-        return makeComponent(metadata, unicode, hover, style).withStyle(
-                Style.EMPTY.withClickEvent(
-                        new ClickEvent(
-                                ClickEvent.Action.COPY_TO_CLIPBOARD,
-                                ":"+key+":"
-                        )
+        return makeComponent(metadata, unicode, hover, style).withStyle(Style.EMPTY.withClickEvent(
+                new ClickEvent(
+                        ClickEvent.Action.COPY_TO_CLIPBOARD,
+                        ":"+key+":"
                 )
-        );
+        ).withColor(style.getColor()));
     }
 
     public MutableComponent getShortcutComponent(String shortcut, Style style) {

--- a/common/src/main/java/org/figuramc/figura/font/EmojiContainer.java
+++ b/common/src/main/java/org/figuramc/figura/font/EmojiContainer.java
@@ -31,7 +31,6 @@ public class EmojiContainer {
 
     private static final String ERROR_MSG = "Invalid emoji metadata \"{}\" @ \"{}\", Reason: Field '{}' {}";
 
-    private static final Style STYLE = Style.EMPTY.withColor(ChatFormatting.WHITE);
 
     public final String name;
     private final ResourceLocation font;
@@ -140,12 +139,8 @@ public class EmojiContainer {
     }
 
     private MutableComponent makeComponent(@Nullable EmojiMetadata metadata, String unicode, MutableComponent hover, Style style) {
-        Style styleToUse = metadata != null && metadata.canBeColored ? style.withBold(false).withItalic(false).withObfuscated(false).withUnderlined(false) : STYLE;
-        if (metadata != null && metadata.canBeColored && styleToUse.getColor() == null) {
-            styleToUse = styleToUse.withColor(metadata.defaultColor);
-        }
-
-        return Component.literal(unicode).withStyle(styleToUse.withFont(font).withHoverEvent(
+        style = style.withBold(false).withItalic(false).withObfuscated(false).withUnderlined(false);
+        return Component.literal(unicode).withStyle(style.withFont(font).withHoverEvent(
                 new HoverEvent(HoverEvent.Action.SHOW_TEXT, hover
                         .append("\n")
                         .append(FiguraText.of("emoji." + name).withStyle(ChatFormatting.DARK_GRAY)))

--- a/common/src/main/java/org/figuramc/figura/font/Emojis.java
+++ b/common/src/main/java/org/figuramc/figura/font/Emojis.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonParser;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
+import net.minecraft.network.chat.TextColor;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.Resource;
 import org.figuramc.figura.FiguraMod;
@@ -15,6 +16,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class Emojis {
 
@@ -23,6 +26,7 @@ public class Emojis {
 
     public static final char DELIMITER = ':';
     public static final char ESCAPE = '\\';
+    public static final Pattern HEX_SUFFIX = Pattern.compile("^(.*?)(#[0-9a-fA-F]{6})$");
 
     // listener to load emojis from the resource pack
     public static final FiguraResourceListener RESOURCE_LISTENER = FiguraResourceListener.createResourceListener("emojis", manager -> {
@@ -169,6 +173,7 @@ public class Emojis {
 
             // even: append text
             if (i % 2 == 0) {
+
                 // Find all emoji shortcuts in string
                 List<String> shortcuts = SHORTCUT_LOOKUP.keySet().stream().filter(s::contains).toList();
 
@@ -197,7 +202,14 @@ public class Emojis {
             }
             // odd: format and append emoji
             else {
-                appendEmoji(result, s, style);
+                TextColor color = TextColor.fromRgb(16777215); // Default to white
+                // Check if the emoji string has a hex code suffix at the end
+                Matcher matcher = HEX_SUFFIX.matcher(s);
+                if (matcher.matches()) {
+                    s = matcher.group(1);
+                    color = TextColor.parseColor(matcher.group(2));
+                }
+                appendEmoji(result, s, style.withColor(color));
             }
         }
 

--- a/common/src/main/java/org/figuramc/figura/font/Emojis.java
+++ b/common/src/main/java/org/figuramc/figura/font/Emojis.java
@@ -202,24 +202,28 @@ public class Emojis {
             }
             // odd: format and append emoji
             else {
-                TextColor color = TextColor.fromRgb(16777215); // Default to white
+                TextColor color = null;
+
                 // Check if the emoji string has a hex code suffix at the end
                 Matcher matcher = HEX_SUFFIX.matcher(s);
                 if (matcher.matches()) {
                     s = matcher.group(1);
                     color = TextColor.parseColor(matcher.group(2));
                 }
-                appendEmoji(result, s, style.withColor(color));
+                appendEmoji(result, s, style, color);
             }
         }
 
         return result;
     }
 
-    private static void appendEmoji(MutableComponent result, String alias, Style style) {
+    private static void appendEmoji(MutableComponent result, String alias, Style style, TextColor color) {
         MutableComponent emoji = Emojis.getEmoji(alias, style);
         
         if (emoji != null) {
+            if (color != null)
+                emoji.setStyle(emoji.getStyle().withColor(color));
+
             result.append(emoji);
         } else {
             result.append(DELIMITER + alias + DELIMITER);


### PR DESCRIPTION
This PR allows users to color emojis by giving them a suffix hex code

format: `:emoji#hex:`
only if the hex is valid in which it will apply the color to said emoji

```text
:clueless#ff0000:
:clueless#00ff00:
:clueless#0000ff:
```
<img width="677" height="348" alt="image" src="https://github.com/user-attachments/assets/9db4e392-930e-4ca1-a688-dbf49c467a88" />
