### PR TITLE
feat: Skull render improvements

### DIFF
--- a/common/src/main/java/org/figuramc/figura/ducks/SkullBlockRendererAccessor.java
+++ b/common/src/main/java/org/figuramc/figura/ducks/SkullBlockRendererAccessor.java
@@ -40,8 +40,8 @@ public abstract class SkullBlockRendererAccessor {
         THIRD_PERSON_LEFT_HAND,
         THIRD_PERSON_RIGHT_HAND,
         BLOCK,
-        ITEM_ENTITY,
-        ITEM_FRAME,
+        GROUND,
+        FIXED,
         GUI,
         OTHER
     }

--- a/common/src/main/java/org/figuramc/figura/ducks/SkullBlockRendererAccessor.java
+++ b/common/src/main/java/org/figuramc/figura/ducks/SkullBlockRendererAccessor.java
@@ -41,6 +41,8 @@ public abstract class SkullBlockRendererAccessor {
         THIRD_PERSON_RIGHT_HAND,
         BLOCK,
         ITEM_ENTITY,
+        ITEM_FRAME,
+        GUI,
         OTHER
     }
 }

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/ItemEntityRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/ItemEntityRendererMixin.java
@@ -18,7 +18,7 @@ public class ItemEntityRendererMixin {
     private void onRender(ItemEntity itemEntity, float f, float g, PoseStack poseStack, MultiBufferSource multiBufferSource, int i, CallbackInfo ci) {
         if (itemEntity.getItem().getItem() instanceof BlockItem bl && bl.getBlock() instanceof AbstractSkullBlock) {
             SkullBlockRendererAccessor.setEntity(itemEntity);
-            SkullBlockRendererAccessor.setRenderMode(SkullBlockRendererAccessor.SkullRenderMode.ITEM_ENTITY);
+            SkullBlockRendererAccessor.setRenderMode(SkullBlockRendererAccessor.SkullRenderMode.GROUND);
         }
     }
 }

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/ItemRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/ItemRendererMixin.java
@@ -6,11 +6,16 @@ import net.minecraft.client.renderer.block.model.ItemTransform;
 import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.AbstractSkullBlock;
+
 import org.figuramc.figura.avatar.Avatar;
 import org.figuramc.figura.avatar.AvatarManager;
+import org.figuramc.figura.ducks.SkullBlockRendererAccessor;
 import org.figuramc.figura.lua.api.world.ItemStackAPI;
 import org.figuramc.figura.math.vector.FiguraVec3;
 import org.jetbrains.annotations.Nullable;
@@ -39,5 +44,13 @@ public abstract class ItemRendererMixin {
 
         if (avatar.itemRenderEvent(ItemStackAPI.verify(itemStack), itemDisplayContext.name(), FiguraVec3.fromVec3f(transform.translation), FiguraVec3.of(transform.rotation.z, transform.rotation.y, transform.rotation.x), FiguraVec3.fromVec3f(transform.scale), leftHanded, stack, buffer, light, overlay))
             ci.cancel();
+    }
+
+    @Inject(at = @At("HEAD"), method = "render(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/ItemDisplayContext;ZLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;IILnet/minecraft/client/resources/model/BakedModel;)V")
+    private void onRender(ItemStack stack, ItemDisplayContext modelTransformationMode, boolean leftHanded, PoseStack matrices, MultiBufferSource vertexConsumers, int light, int overlay, BakedModel model, CallbackInfo ci) {
+        if (modelTransformationMode == ItemDisplayContext.GROUND && stack.getItem() instanceof BlockItem bl && bl.getBlock() instanceof AbstractSkullBlock) {
+            SkullBlockRendererAccessor.setItem(stack);
+            SkullBlockRendererAccessor.setRenderMode(SkullBlockRendererAccessor.SkullRenderMode.ITEM_ENTITY);
+        }
     }
 }

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/ItemRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/ItemRendererMixin.java
@@ -16,6 +16,7 @@ import net.minecraft.world.level.block.AbstractSkullBlock;
 import org.figuramc.figura.avatar.Avatar;
 import org.figuramc.figura.avatar.AvatarManager;
 import org.figuramc.figura.ducks.SkullBlockRendererAccessor;
+import org.figuramc.figura.ducks.SkullBlockRendererAccessor.SkullRenderMode;
 import org.figuramc.figura.lua.api.world.ItemStackAPI;
 import org.figuramc.figura.math.vector.FiguraVec3;
 import org.jetbrains.annotations.Nullable;
@@ -48,9 +49,19 @@ public abstract class ItemRendererMixin {
 
     @Inject(at = @At("HEAD"), method = "render(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/ItemDisplayContext;ZLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;IILnet/minecraft/client/resources/model/BakedModel;)V")
     private void onRender(ItemStack stack, ItemDisplayContext modelTransformationMode, boolean leftHanded, PoseStack matrices, MultiBufferSource vertexConsumers, int light, int overlay, BakedModel model, CallbackInfo ci) {
-        if (modelTransformationMode == ItemDisplayContext.GROUND && stack.getItem() instanceof BlockItem bl && bl.getBlock() instanceof AbstractSkullBlock) {
+        if (stack.getItem() instanceof BlockItem bl && bl.getBlock() instanceof AbstractSkullBlock) {
+            SkullRenderMode mode = switch (modelTransformationMode) {
+                case GROUND -> SkullBlockRendererAccessor.SkullRenderMode.ITEM_ENTITY;
+                case FIXED -> SkullBlockRendererAccessor.SkullRenderMode.ITEM_FRAME;
+                case GUI -> SkullBlockRendererAccessor.SkullRenderMode.GUI;
+                default -> null;
+            };
+
+            if (mode == null)
+                return;
+
             SkullBlockRendererAccessor.setItem(stack);
-            SkullBlockRendererAccessor.setRenderMode(SkullBlockRendererAccessor.SkullRenderMode.ITEM_ENTITY);
+            SkullBlockRendererAccessor.setRenderMode(mode);
         }
     }
 }

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/ItemRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/ItemRendererMixin.java
@@ -51,8 +51,8 @@ public abstract class ItemRendererMixin {
     private void onRender(ItemStack stack, ItemDisplayContext modelTransformationMode, boolean leftHanded, PoseStack matrices, MultiBufferSource vertexConsumers, int light, int overlay, BakedModel model, CallbackInfo ci) {
         if (stack.getItem() instanceof BlockItem bl && bl.getBlock() instanceof AbstractSkullBlock) {
             SkullRenderMode mode = switch (modelTransformationMode) {
-                case GROUND -> SkullBlockRendererAccessor.SkullRenderMode.ITEM_ENTITY;
-                case FIXED -> SkullBlockRendererAccessor.SkullRenderMode.ITEM_FRAME;
+                case GROUND -> SkullBlockRendererAccessor.SkullRenderMode.GROUND;
+                case FIXED -> SkullBlockRendererAccessor.SkullRenderMode.FIXED;
                 case GUI -> SkullBlockRendererAccessor.SkullRenderMode.GUI;
                 default -> null;
             };

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/ItemRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/ItemRendererMixin.java
@@ -62,6 +62,8 @@ public abstract class ItemRendererMixin {
 
             SkullBlockRendererAccessor.setItem(stack);
             SkullBlockRendererAccessor.setRenderMode(mode);
+            if (modelTransformationMode == ItemDisplayContext.FIXED)
+                SkullBlockRendererAccessor.setEntity(stack.getFrame());
         }
     }
 }


### PR DESCRIPTION
Changes:
* Renames ITEM_ENTITY added in another 0.1.6 PR to GROUND to align with existing render contexts
* Adds FIXED render type for skulls rendered in the item frame
* Adds GUI render type for skulls rendered inside containers
* Made sure all skulls which render on an entity pass that entity through the skull render event

Fixes:
* Fixes GROUND context not applying to stacks of dropped items