### PR TITLE
feat: Watch symlinked scripts, reload the avatar

### DIFF
--- a/common/src/main/java/org/figuramc/figura/avatar/local/LocalAvatarLoader.java
+++ b/common/src/main/java/org/figuramc/figura/avatar/local/LocalAvatarLoader.java
@@ -326,7 +326,7 @@ public class LocalAvatarLoader {
                 Path path = entry.getKey().resolve((Path) event.context());
                 String name = IOUtils.getFileNameOrEmpty(path);
 
-                if (IOUtils.isHiddenAvatarResource(path) || !(Files.isDirectory(path) || name.matches("(.*(\\.lua|\\.bbmodel|\\.ogg|\\.png)$|avatar\\.json)")))
+                if (IOUtils.isHiddenResource(path, entry.getKey()) || !(Files.isDirectory(path) || name.matches("(.*(\\.lua|\\.bbmodel|\\.ogg|\\.png)$|avatar\\.json)")))
                     continue;
 
                 if (kind == StandardWatchEventKinds.ENTRY_CREATE && !IS_WINDOWS)
@@ -372,13 +372,26 @@ public class LocalAvatarLoader {
             WatchKey key = IS_WINDOWS ? path.register(watcher, events, com.sun.nio.file.ExtendedWatchEventModifier.FILE_TREE) : path.register(watcher, events);
 
             consumer.accept(path, key);
+            if (IS_WINDOWS) {
+                Files.walk(path)
+                        .filter(Files::isSymbolicLink)
+                        .filter(Files::isDirectory)
+                        .forEach(symlink -> {
+                            try {
+                                symlink = symlink.toRealPath();
+                                addWatchKey(symlink, consumer);
+                            } catch (IOException e) {
+                                FiguraMod.LOGGER.error("Failed to register symbolic watcher for " + symlink, e);
+                            }
+                        });
+            } else {
+                List<Path> children = IOUtils.listPaths(path);
+                if (children == null)
+                    return;
 
-            List<Path> children = IOUtils.listPaths(path);
-            if (children == null || IS_WINDOWS)
-                return;
-
-            for (Path child : children)
-                addWatchKey(child, consumer);
+                for (Path child : children)
+                    addWatchKey(child, consumer);
+            }
         } catch (Exception e) {
             FiguraMod.LOGGER.error("Failed to register watcher for " + path, e);
         }

--- a/common/src/main/java/org/figuramc/figura/utils/IOUtils.java
+++ b/common/src/main/java/org/figuramc/figura/utils/IOUtils.java
@@ -167,6 +167,30 @@ public class IOUtils {
         return hidden || getFileNameOrEmpty(path).startsWith(".");
     }
 
+    /*
+     * Same as isHiddenAvatarResource but allows for setting the root path.
+     * Intended for when a script needs to reload the avatar but it exists outside
+     * the avatar through a symlink.
+     */
+    public static boolean isHiddenResource(@NotNull Path path, @NotNull Path root) {
+        try {
+            // Iterate through all parent folders of the avatars
+            // resource to find a hidden one (if any)
+            for (Path parent = path;
+                 !Files.isSameFile(parent, root);
+                 parent = parent.resolve("..").normalize()) {
+                FiguraMod.LOGGER.info(parent + " " + Files.isHidden(parent));
+                if (Files.isHidden(parent) || parent.getFileName().toString().startsWith(".")) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (IOException e) {
+            FiguraMod.LOGGER.error("Failed to get if \"" + path + "\" is hidden", e);
+            return false;
+        }
+    }
+
     /**
      * Checks, if given file is a hidden avatar resource.
      * Avatar resource is hidden, if it is contained within

--- a/common/src/main/java/org/figuramc/figura/utils/IOUtils.java
+++ b/common/src/main/java/org/figuramc/figura/utils/IOUtils.java
@@ -179,7 +179,6 @@ public class IOUtils {
             for (Path parent = path;
                  !Files.isSameFile(parent, root);
                  parent = parent.resolve("..").normalize()) {
-                FiguraMod.LOGGER.info(parent + " " + Files.isHidden(parent));
                 if (Files.isHidden(parent) || parent.getFileName().toString().startsWith(".")) {
                     return true;
                 }


### PR DESCRIPTION
This commit allows for scripts that exist in symlinked folders to be watched and reload the avatar. This does not change what scripts can be loaded by the avatar.