### PR TITLE
fix: vectors.toCameraSpace

### DIFF
--- a/common/src/main/java/org/figuramc/figura/utils/MathUtils.java
+++ b/common/src/main/java/org/figuramc/figura/utils/MathUtils.java
@@ -80,7 +80,7 @@ public class MathUtils {
         FiguraVec3 ret = vec.copy();
         ret.subtract(pos.x, pos.y, pos.z);
         ret.transform(transformMatrix);
-        // ret.multiply(-1, 1, 1);
+        ret.multiply(-1, 1, -1); // 1.21 bug causes the z to flip. All other values are normal when comparing to <1.21
 
         return ret;
     }


### PR DESCRIPTION
Fixed values returned by vectors.toCameraSpace() to match <1.21