### PR TITLE
Fix: Crash when viewing pivot outlines

### DIFF
--- a/common/src/main/java/org/figuramc/figura/model/rendering/ImmediateAvatarRenderer.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendering/ImmediateAvatarRenderer.java
@@ -8,6 +8,7 @@ import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LightLayer;
@@ -344,8 +345,8 @@ public class ImmediateAvatarRenderer extends AvatarRenderer {
 
                 // Store calculated light level and current overlay effect before pushing pose stack
                 PartCustomization oldPeek = customizationStack.peek();
-                int light = oldPeek.light;
-                int overlay = oldPeek.overlay;
+                int light = oldPeek.light != null ? oldPeek.light : LightTexture.FULL_BRIGHT;
+                int overlay = oldPeek.overlay != null ? oldPeek.light : OverlayTexture.NO_OVERLAY;
 
                 FiguraVec3 pivot = custom.getPivot().copy().add(custom.getOffsetPivot());
                 pivotOffsetter.setPos(pivot);

--- a/common/src/main/java/org/figuramc/figura/model/rendering/ImmediateAvatarRenderer.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendering/ImmediateAvatarRenderer.java
@@ -340,13 +340,13 @@ public class ImmediateAvatarRenderer extends AvatarRenderer {
             boolean renderPivotParts = part.parentType.isPivot && allowPivotParts;
 
             if (renderPivot || renderTasks || renderPivotParts) {
+                // fix light and overlay
+                PartCustomization parent = customizationStack.peek();
+                int light = parent.light != null ? parent.light : LightTexture.FULL_BRIGHT;
+                int overlay = parent.overlay != null ? parent.overlay : OverlayTexture.NO_OVERLAY;
+
                 // fix pivots
                 FiguraMod.pushProfiler("fixMatricesPivot");
-
-                // Store calculated light level and current overlay effect before pushing pose stack
-                PartCustomization oldPeek = customizationStack.peek();
-                int light = oldPeek.light != null ? oldPeek.light : LightTexture.FULL_BRIGHT;
-                int overlay = oldPeek.overlay != null ? oldPeek.light : OverlayTexture.NO_OVERLAY;
 
                 FiguraVec3 pivot = custom.getPivot().copy().add(custom.getOffsetPivot());
                 pivotOffsetter.setPos(pivot);


### PR DESCRIPTION
Added a null check to task light and overlay retrieved from its parent ModelPart