### PR TITLE
Fix: Actually use FSB configuration file for defaults on Forge

### DIFF
--- a/forge/src/main/java/org/figuramc/figura/forge/FiguraForgePermissions.java
+++ b/forge/src/main/java/org/figuramc/figura/forge/FiguraForgePermissions.java
@@ -1,20 +1,16 @@
 package org.figuramc.figura.forge;
 
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.server.permission.PermissionAPI;
 import net.minecraftforge.server.permission.events.PermissionGatherEvent;
-import net.minecraftforge.server.permission.nodes.PermissionDynamicContext;
 import net.minecraftforge.server.permission.nodes.PermissionNode;
 import net.minecraftforge.server.permission.nodes.PermissionTypes;
 import org.figuramc.figura.server.FiguraModServer;
 import org.figuramc.figura.server.FiguraPermissionNodes;
 import org.figuramc.figura.server.FiguraPermissions;
+import org.figuramc.figura.server.FiguraServer;
 import org.figuramc.figura.server.utils.Pair;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
-import java.util.UUID;
 
 public class FiguraForgePermissions {
 
@@ -24,8 +20,8 @@ public class FiguraForgePermissions {
         });
     }};
     private static final HashMap<FiguraPermissionNodes, PermissionNode<?>> registeredOption = new HashMap<>() {{
-        FiguraPermissions.OPTIONS_LIST.forEach((pair) -> {
-            put(pair.left(), createOption(pair));
+        FiguraPermissions.OPTIONS_LIST.forEach((node) -> {
+            put(node, createOption(node, FiguraServer.getInstance().getOptionDefault(node) + ""));
         });
     }};
 
@@ -35,10 +31,9 @@ public class FiguraForgePermissions {
         return new PermissionNode<>(FiguraModServer.MOD_ID, name, PermissionTypes.BOOLEAN, (a,b,c) -> defaultVal);
     }
 
-    public static PermissionNode<String> createOption(Pair<FiguraPermissionNodes, String> pair) {
-        String name = pair.left().toString();
-        String defaultVal = pair.right();
-        return new PermissionNode<>(FiguraModServer.MOD_ID, name, PermissionTypes.STRING, (a,b,c) -> defaultVal);
+    public static PermissionNode<String> createOption(FiguraPermissionNodes node, String def) {
+        String name = node.toString();
+        return new PermissionNode<>(FiguraModServer.MOD_ID, name, PermissionTypes.STRING, (a,b,c) -> def);
     }
 
     @SubscribeEvent

--- a/server-common/src/main/java/org/figuramc/figura/server/FiguraPermissions.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/FiguraPermissions.java
@@ -10,10 +10,10 @@ public class FiguraPermissions {
             Pair.of(FIGURA_AVATARS_IMMORTALIZE, false),
             Pair.of(FIGURA_AVATARS_SET, false)
     );
-    public static final List<Pair<FiguraPermissionNodes, String>> OPTIONS_LIST = List.of(
-            Pair.of(FIGURA_PINGS_RATELIMIT, 32+""),
-            Pair.of(FIGURA_PINGS_SIZELIMIT, 1024+""),
-            Pair.of(FIGURA_AVATARS_SIZELIMIT, 102400+""),
-            Pair.of(FIGURA_AVATARS_COUNTLIMIT, 1+"")
+    public static final List<FiguraPermissionNodes> OPTIONS_LIST = List.of(
+            FIGURA_PINGS_RATELIMIT,
+            FIGURA_PINGS_SIZELIMIT,
+            FIGURA_AVATARS_SIZELIMIT,
+            FIGURA_AVATARS_COUNTLIMIT
     );
 }

--- a/server-common/src/main/java/org/figuramc/figura/server/FiguraServer.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/FiguraServer.java
@@ -133,6 +133,16 @@ public abstract class FiguraServer {
         catch (IOException ignored) {}
     }
 
+    public final int getOptionDefault(FiguraPermissionNodes node) {
+        return switch (node) {
+            case FIGURA_AVATARS_IMMORTALIZE, FIGURA_AVATARS_SET, FIGURA_AVATARS_CLEAR -> throw new IllegalArgumentException();
+            case FIGURA_PINGS_RATELIMIT -> config.getDefaultPingsRateLimit();
+            case FIGURA_PINGS_SIZELIMIT -> config.getDefaultPingsSizeLimit();
+            case FIGURA_AVATARS_SIZELIMIT -> config.getDefaultAvatarSizeLimit();
+            case FIGURA_AVATARS_COUNTLIMIT -> config.getDefaultAvatarsCountLimit();
+        };
+    }
+
     public final C2SPacketHandler<Packet> getPacketHandler(Identifier id) {
         return (C2SPacketHandler<Packet>) PACKET_HANDLERS.get(id);
     }

--- a/server-common/src/main/java/org/figuramc/figura/server/FiguraServerConfig.java
+++ b/server-common/src/main/java/org/figuramc/figura/server/FiguraServerConfig.java
@@ -9,11 +9,27 @@ public final class FiguraServerConfig {
     private int pingsRateLimit = 32;
     @SerializedName("pingsSizeLimit")
     private int pingsSizeLimit = 1024;
-
     @SerializedName("avatarSizeLimit")
     private int avatarSizeLimit = 102400;
     @SerializedName("avatarCountLimit")
     private int avatarsCountLimit = 1;
+
+    public int getDefaultPingsRateLimit() {
+        return pingsRateLimit;
+    }
+
+    public int getDefaultPingsSizeLimit() {
+        return pingsSizeLimit;
+    }
+
+    public int getDefaultAvatarSizeLimit() {
+        return avatarSizeLimit;
+    }
+
+    public int getDefaultAvatarsCountLimit() {
+        return avatarsCountLimit;
+    }
+
 
     public int pingsRateLimit(FiguraServer server, UUID player) {
         return Integer.parseInt(server.getOption(player, FiguraPermissionNodes.FIGURA_PINGS_RATELIMIT).orElse(pingsRateLimit + ""));


### PR DESCRIPTION
Previously, default permissions on Forge were hardcoded to the default-defaults [is that a thing?] meaning everyone was stuck at 100KiB

This needs some porting to the Neo section of the codebase as well probably once this gets cascaded into 1.20.2