### PR TITLE
1.20.2 figurav5addon compatibility extensions

### DIFF
--- a/neoforge/src/main/resources/META-INF/mods.toml
+++ b/neoforge/src/main/resources/META-INF/mods.toml
@@ -32,6 +32,15 @@ versionRange = "[${minecraft_version},)"
 ordering = "NONE"
 side = "BOTH"
 
+# this addon is a port of features already included, so we want to trigger
+# a "friendly" dependency conflict instead of running into a mixin error
+[[dependencies.figura]]
+modId = "figurav5addon"
+mandatory = false
+versionRange = "[NONE - §cincompatible§r\\nThis addon's features are included in this Figura version!]"
+ordering = "NONE"
+side = "BOTH"
+
 [[mixins]]
 config = "figura-common.mixins.json"
 [[mixins]]


### PR DESCRIPTION
Companion to #448.

Adds a conflict on `figurav5addon` on NeoForge 1.20.2 to hopefully direct users to uninstall the addon when installing 0.1.6.

(This copies the changes from the Forge conflict in #448 into the NeoForge `mods.toml`.)

Fabric and Forge conflicts are included in #448.

**This PR does not actually change the Blockbench parser.** It is a companion for #448, which actually does have the changes.