### PR TITLE
1.20.4+ figurav5addon compatibility extensions

### DIFF
--- a/neoforge/src/main/resources/META-INF/mods.toml
+++ b/neoforge/src/main/resources/META-INF/mods.toml
@@ -32,6 +32,11 @@ versionRange = "[${minecraft_version},)"
 ordering = "NONE"
 side = "BOTH"
 
+[[dependencies.figura]]
+modId = "figurav5addon"
+type = "incompatible"
+reason = "This addon's features are already included in this Figura version!"
+
 [[mixins]]
 config = "figura-common.mixins.json"
 [[mixins]]


### PR DESCRIPTION
Companion to #448 and #464.

Merge and cascade #464 first. (Or pick this side when merge conflicting.)

Adds a conflict on `figurav5addon` on NeoForge 1.20.4 to hopefully direct users to uninstall the addon when installing 0.1.6.

(This is different from #464 because NeoForge 1.20.2 actually uses the Forge `mods.toml` format, instead of the NeoForge `mods.toml` format which supports `type = "incompatible"`)

Fabric and Forge conflicts are included in #448.

**This PR does not actually change the Blockbench parser.** It is a companion for #448, which actually does have the changes.