### PR TITLE
Fix crash with EntityCulling & the players arm not showing up in first person

### DIFF
--- a/common/src/main/java/org/figuramc/figura/mixin/render/EntityRenderDispatcherMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/EntityRenderDispatcherMixin.java
@@ -65,7 +65,10 @@ public class EntityRenderDispatcherMixin {
         if (this.camera == null)
             ci.cancel();
 
-        Entity entity = Minecraft.getInstance().level.getEntity(((FiguraEntityRenderStateExtension)entityRenderState).figura$getEntityId());
+        Integer entityId = ((FiguraEntityRenderStateExtension)entityRenderState).figura$getEntityId();
+        if (entityId == null)
+            return;
+        Entity entity = Minecraft.getInstance().level.getEntity(entityId);
         if (entity == null)
             return;
         Entity owner = entity.getFirstPassenger();

--- a/common/src/main/java/org/figuramc/figura/mixin/render/LevelRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/LevelRendererMixin.java
@@ -50,7 +50,9 @@ public abstract class LevelRendererMixin {
 
     @Inject(method = "submitEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/entity/EntityRenderDispatcher;submit(Lnet/minecraft/client/renderer/entity/state/EntityRenderState;Lnet/minecraft/client/renderer/state/CameraRenderState;DDDLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;)V"))
     private <S extends EntityRenderState> void renderEntity(PoseStack poseStack, LevelRenderState levelRenderState, SubmitNodeCollector submitNodeCollector, CallbackInfo ci, @Local S entityRenderState) {
-        Entity entity = Minecraft.getInstance().level.getEntity(((FiguraEntityRenderStateExtension)entityRenderState).figura$getEntityId());
+        Integer entityId = ((FiguraEntityRenderStateExtension)entityRenderState).figura$getEntityId();
+        if (entityId == null) return;
+        Entity entity = Minecraft.getInstance().level.getEntity(entityId);
         float tickDelta = ((FiguraEntityRenderStateExtension)entityRenderState).figura$getTickDelta();
 
         Avatar av = AvatarManager.getAvatar(entityRenderState);

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/LivingEntityRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/LivingEntityRendererMixin.java
@@ -136,7 +136,9 @@ public abstract class LivingEntityRendererMixin<T extends LivingEntity, S extend
             return true;
         });
 
-        int entityId = ((FiguraEntityRenderStateExtension)livingEntityRenderState).figura$getEntityId();
+        Integer entityIdBoxed = ((FiguraEntityRenderStateExtension)livingEntityRenderState).figura$getEntityId();
+        if (entityIdBoxed == null) return;
+        int entityId = entityIdBoxed;
         float tickDelta = ((FiguraEntityRenderStateExtension)livingEntityRenderState).figura$getTickDelta();
 
         Entity entity = Minecraft.getInstance().level.getEntity(entityId);

--- a/common/src/main/java/org/figuramc/figura/mixin/render/renderers/PlayerRendererMixin.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/render/renderers/PlayerRendererMixin.java
@@ -180,12 +180,12 @@ public abstract class PlayerRendererMixin extends LivingEntityRenderer<AbstractC
                     part.posTransform(model);
                 }
             }
-            return false;
+            return true;
         };
 
         ((FiguraSubmitCallBackExtension)(Object)modelPart).figura$setPreRenderingCallback(lambda);
         ((FiguraSubmitCallBackExtension)(Object)modelPart).figura$setPostRenderingCallback(() -> {
-            if (avatar.luaRuntime != null)
+            if (avatar != null && avatar.luaRuntime != null)
                 avatar.luaRuntime.vanilla_model.PLAYER.restore(model);
             }
         );


### PR DESCRIPTION
Fixes NPE crashes caused by figura$getEntityId returning null when EntityCulling bypasses extractRenderState and fixes arms not rendering in first person due to the prerender callback incorrectly cancelling vanilla arm rendering