### PR TITLE
Fix crash when checking offline status in single player

### DIFF
--- a/common/src/main/java/org/figuramc/figura/FiguraMod.java
+++ b/common/src/main/java/org/figuramc/figura/FiguraMod.java
@@ -1,6 +1,7 @@
 package org.figuramc.figura;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
 import net.minecraft.server.players.GameProfileCache;
@@ -130,7 +131,8 @@ public class FiguraMod {
     }
 
     public static boolean isOffline(UUID other) {
-        return !Minecraft.getInstance().getConnection().getOnlinePlayerIds().contains(other);
+        ClientPacketListener connection = Minecraft.getInstance().getConnection();
+        return connection == null || !connection.getOnlinePlayerIds().contains(other);
     }
 
     /**


### PR DESCRIPTION
Fixes #488

The isOffline check was crashing in single player mode because the connection can be null. Added a simple null check before we try to access the online player list.