### PR TITLE
Fix BlockBehaviourAccessor accessor

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/api/world/BlockStateAPI.java
+++ b/common/src/main/java/org/figuramc/figura/lua/api/world/BlockStateAPI.java
@@ -244,7 +244,7 @@ public class BlockStateAPI {
     @LuaWhitelist
     @LuaMethodDoc("blockstate.has_collision")
     public boolean hasCollision() {
-        return ((BlockBehaviourAccessor) blockState.getBlock()).hasCollision();
+        return ((BlockBehaviourAccessor) blockState.getBlock()).getHasCollision();
     }
 
     @LuaWhitelist

--- a/common/src/main/java/org/figuramc/figura/mixin/BlockBehaviourAccessor.java
+++ b/common/src/main/java/org/figuramc/figura/mixin/BlockBehaviourAccessor.java
@@ -9,5 +9,5 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 public interface BlockBehaviourAccessor {
     @Intrinsic
     @Accessor("hasCollision")
-    boolean hasCollision();
+    boolean getHasCollision();
 }


### PR DESCRIPTION
`BlockBehaviourAccessor.java` names its accessor method the same name as the field. In addition to being inconsistent with the other accessors in the mod, this causes crashes with modpacks that rely on the non-existence of the method. e.g. [TerraFirmaGreg](https://github.com/TerraFirmaGreg-Team/Modpack-Modern/blob/e81a569fdacaaf83c5725f07ac01381c35e75824/kubejs/startup_scripts/minecraft/modifications.js#L54) assigns to this field:

```js
	event.modify('minecraft:cherry_leaves', block => {
		block.hasCollision = false
		block.speedFactor = 0.25
	})
```

And fails with
```
[12:51:47] [ERROR] ! minecraft/modifications.js#54: Error in 'BlockEvents.modification': Java method "hasCollision" cannot be assigned to.
[12:51:47] [ERROR] ! …rhino.EvaluatorException: Java method "hasCollision" cannot be assigned to. (startup_scripts:minecraft/modifications.js#54)
```
if Figura is installed.

This PR changes the name of the `hasCollision` accessor to `getHasCollision`.

Cheers