### PR TITLE
0.1.6 → 0.1.7 [1.20]

### DIFF
--- a/common/src/main/java/org/figuramc/figura/avatar/AvatarManager.java
+++ b/common/src/main/java/org/figuramc/figura/avatar/AvatarManager.java
@@ -321,9 +321,11 @@ public class AvatarManager {
             }
 
             if (LOADED_USERS.get(targetUUID) != null) {
+                if (FiguraMod.isLocal(targetUUID)) {
+                    context.getSource().figura$sendError(Component.literal("Cannot set your own avatar this way; use '/figura load' instead"));
+                    return 0;
+                }
                 setAvatar(targetUUID, avatar.nbt);
-                if (FiguraMod.isLocal(targetUUID))
-                    localUploaded = true;
                 context.getSource().figura$sendFeedback(Component.literal("Set avatar for " + t));
                 return 1;
             }

--- a/common/src/main/java/org/figuramc/figura/exporters/BlockBenchModel.java
+++ b/common/src/main/java/org/figuramc/figura/exporters/BlockBenchModel.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 
 public class BlockBenchModel {
 
-    private static final String VERSION = "4.9";
+    private static final String VERSION = "4.10";
 
     private final JsonObject root = new JsonObject();
     private final ArrayList<Cube> elements = new ArrayList<>();
@@ -176,6 +176,7 @@ public class BlockBenchModel {
             cube.add("to", vec3ToJson(position.plus(size)));
             cube.addProperty("inflate", inflate);
             cube.add("faces", faces);
+            cube.addProperty("type", "cube");
             return cube;
         }
 

--- a/common/src/main/java/org/figuramc/figura/lua/LuaTypeManager.java
+++ b/common/src/main/java/org/figuramc/figura/lua/LuaTypeManager.java
@@ -9,10 +9,10 @@ import org.luaj.vm2.lib.TwoArgFunction;
 import org.luaj.vm2.lib.VarArgFunction;
 
 import java.lang.reflect.*;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+
+import static java.util.Map.entry;
+import static org.luaj.vm2.LuaValue.*;
 
 /**
  * One LuaTypeManager per LuaRuntime, so that people can be allowed to edit the metatables within.
@@ -153,9 +153,32 @@ public class LuaTypeManager {
                     } catch (LuaError e) {
                         String methodName = method.getName();
                         String targetType = getTypeName(clazz);
+                        if (OPERATORS.containsKey(methodName)) {
+                            String typeName;
+                            if (args.isuserdata(1)) {
+                                typeName = FiguraDocsManager.getNameFor(args.checkuserdata(1).getClass());
+                            } else typeName = args.arg1().typename();
+
+                            OperatorInfo operator = OPERATORS.get(methodName);
+                            if (operator.binary) throw new LuaError(String.format(
+                                    "Expected left-hand side of %s to be a %s; actually got %s",
+                                    operator.name,
+                                    targetType,
+                                    typeName
+                            ));
+                            else throw new LuaError(String.format(
+                                    "Expected subject of %s to be a %s; actually got %s",
+                                    operator.name,
+                                    targetType,
+                                    typeName
+                            ));
+                        }
                         throw new LuaError(String.format(
                                 "Use a colon (:) to call %s on a %s, instead of a dot.\nFor example, change .%s( to :%s(",
-                                methodName, targetType, methodName, methodName
+                                methodName,
+                                targetType,
+                                methodName,
+                                methodName
                         ));
                     }
                 }
@@ -354,4 +377,25 @@ public class LuaTypeManager {
         else
             return wrap(val);
     }
+
+    private record OperatorInfo(String name, boolean binary) {}
+
+    private static final Map<String, OperatorInfo> OPERATORS = Map.ofEntries(
+            entry(INDEX.tojstring(), new OperatorInfo("indexing", true)),
+            entry(NEWINDEX.tojstring(), new OperatorInfo("indexing", true)),
+            entry(CALL.tojstring(), new OperatorInfo("function call", false)),
+            entry(ADD.tojstring(), new OperatorInfo("+", true)),
+            entry(SUB.tojstring(), new OperatorInfo("-", true)),
+            entry(DIV.tojstring(), new OperatorInfo("/", true)),
+            entry(MUL.tojstring(), new OperatorInfo("*", true)),
+            entry(POW.tojstring(), new OperatorInfo("^", true)),
+            entry(MOD.tojstring(), new OperatorInfo("%", true)),
+            entry(UNM.tojstring(), new OperatorInfo("-", false)),
+            entry(LEN.tojstring(), new OperatorInfo("#", false)),
+            entry(EQ.tojstring(), new OperatorInfo("==", true)),
+            entry(LT.tojstring(), new OperatorInfo("<", true)),
+            entry(LE.tojstring(), new OperatorInfo("<=", true)),
+            entry(TOSTRING.tojstring(), new OperatorInfo("tostring", false)),
+            entry(CONCAT.tojstring(), new OperatorInfo("..", true))
+    );
 }

--- a/common/src/main/java/org/figuramc/figura/math/vector/FiguraVec2.java
+++ b/common/src/main/java/org/figuramc/figura/math/vector/FiguraVec2.java
@@ -566,16 +566,21 @@ public class FiguraVec2 extends FiguraVector<FiguraVec2, FiguraMat2> {
                     )
             }
     )
-    public FiguraVec2 __div(@LuaNotNil Object rhs) {
-        if (rhs instanceof Number n) {
+    public static FiguraVec2 __div(@LuaNotNil Object lhs, @LuaNotNil Object rhs) {
+        if (lhs instanceof FiguraVec2 lvec) {
+            if (rhs instanceof FiguraVec2 rvec) return lvec.dividedBy(rvec);
+            if (rhs instanceof Number n) {
+                double d = n.doubleValue();
+                if (d == 0) throw new LuaError("Attempt to divide vector by 0");
+                return lvec.scaled(1 / d);
+            }
+        } else if (lhs instanceof Number n && rhs instanceof FiguraVec2 rvec) {
             double d = n.doubleValue();
-            if (d == 0)
-                throw new LuaError("Attempt to divide vector by 0");
-            return scaled(1 / d);
-        } else if (rhs instanceof FiguraVec2 vec) {
-            return dividedBy(vec);
+            return FiguraVec2.of(d / rvec.x, d / rvec.y);
         }
-        throw new LuaError("Invalid types to __div: " + getClass().getSimpleName() + ", " + rhs.getClass().getSimpleName());
+        throw new LuaError(
+                "Invalid types to __div: " + lhs.getClass().getSimpleName() + ", " + rhs.getClass().getSimpleName()
+        );
     }
 
     @LuaWhitelist

--- a/common/src/main/java/org/figuramc/figura/math/vector/FiguraVec3.java
+++ b/common/src/main/java/org/figuramc/figura/math/vector/FiguraVec3.java
@@ -639,16 +639,21 @@ public class FiguraVec3 extends FiguraVector<FiguraVec3, FiguraMat3> {
                     )
             }
     )
-    public FiguraVec3 __div(@LuaNotNil Object rhs) {
-        if (rhs instanceof Number n) {
+    public static FiguraVec3 __div(@LuaNotNil Object lhs, @LuaNotNil Object rhs) {
+        if (lhs instanceof FiguraVec3 lvec) {
+            if (rhs instanceof FiguraVec3 rvec) return lvec.dividedBy(rvec);
+            if (rhs instanceof Number n) {
+                double d = n.doubleValue();
+                if (d == 0) throw new LuaError("Attempt to divide vector by 0");
+                return lvec.scaled(1 / d);
+            }
+        } else if (lhs instanceof Number n && rhs instanceof FiguraVec3 rvec) {
             double d = n.doubleValue();
-            if (d == 0)
-                throw new LuaError("Attempt to divide vector by 0");
-            return scaled(1 / d);
-        } else if (rhs instanceof FiguraVec3 vec) {
-            return dividedBy(vec);
+            return FiguraVec3.of(d / rvec.x, d / rvec.y, d / rvec.z);
         }
-        throw new LuaError("Invalid types to __div: " + getClass().getSimpleName() + ", " + rhs.getClass().getSimpleName());
+        throw new LuaError(
+                "Invalid types to __div: " + lhs.getClass().getSimpleName() + ", " + rhs.getClass().getSimpleName()
+        );
     }
 
     @LuaWhitelist

--- a/common/src/main/java/org/figuramc/figura/math/vector/FiguraVec4.java
+++ b/common/src/main/java/org/figuramc/figura/math/vector/FiguraVec4.java
@@ -606,16 +606,21 @@ public class FiguraVec4 extends FiguraVector<FiguraVec4, FiguraMat4> {
                     )
             }
     )
-    public FiguraVec4 __div(@LuaNotNil Object rhs) {
-        if (rhs instanceof Number n) {
+    public static FiguraVec4 __div(@LuaNotNil Object lhs, @LuaNotNil Object rhs) {
+        if (lhs instanceof FiguraVec4 lvec) {
+            if (rhs instanceof FiguraVec4 rvec) return lvec.dividedBy(rvec);
+            if (rhs instanceof Number n) {
+                double d = n.doubleValue();
+                if (d == 0) throw new LuaError("Attempt to divide vector by 0");
+                return lvec.scaled(1 / d);
+            }
+        } else if (lhs instanceof Number n && rhs instanceof FiguraVec4 rvec) {
             double d = n.doubleValue();
-            if (d == 0)
-                throw new LuaError("Attempt to divide vector by 0");
-            return scaled(1 / d);
-        } else if (rhs instanceof FiguraVec4 vec) {
-            return dividedBy(vec);
+            return FiguraVec4.of(d / rvec.x, d / rvec.y, d / rvec.z, d / rvec.w);
         }
-        throw new LuaError("Invalid types to __div: " + getClass().getSimpleName() + ", " + rhs.getClass().getSimpleName());
+        throw new LuaError(
+                "Invalid types to __div: " + lhs.getClass().getSimpleName() + ", " + rhs.getClass().getSimpleName()
+        );
     }
 
     @LuaWhitelist

--- a/common/src/main/java/org/figuramc/figura/wizards/AvatarWizard.java
+++ b/common/src/main/java/org/figuramc/figura/wizards/AvatarWizard.java
@@ -243,6 +243,8 @@ public class AvatarWizard {
             model.setResolution(64, 64);
         else if (hasCapeOrElytra)
             model.setResolution(64, 32);
+        else
+            model.setResolution(16, 16);
 
         //base bones
         Group root = model.addGroup("root", FiguraVec3.of());

--- a/common/src/main/resources/assets/figura/lang/en_us.json
+++ b/common/src/main/resources/assets/figura/lang/en_us.json
@@ -34,6 +34,8 @@
     "figura.toast.load_error": "Failed to load avatar!",
     "figura.toast.wardrobe_copy.success": "Copied %s file(s)!",
     "figura.toast.wardrobe_copy.error": "Failed to copy files!",
+    "figura.toast.zip_load_error": "See game log for details",
+    "figura.toast.zip_load_error.why": "Error: %s",
     "figura.toast.cache_clear": "Cleared Cache!",
     "figura.toast.avatar_data_clear": "Cleared Avatar Data!",
     "figura.permissions.category.blocked": "Blocked",


### PR DESCRIPTION
This brings over the following changes that were made in 0.1.6 and not already included in the 0.1.7 tree for 1.20:
- the Avatar Wizard now generates valid model files again
- the error about `:` vs `.` is no longer used for metamethods (ex. if you try to do `number > vector`)
- dividing a number by a vector is now allowed (result is `{n/x, n/y, n/z}`)
