### PR TITLE
make ListDocs and SchemeFunction public

### DIFF
--- a/common/src/main/java/org/figuramc/figura/lua/docs/FiguraListDocs.java
+++ b/common/src/main/java/org/figuramc/figura/lua/docs/FiguraListDocs.java
@@ -140,7 +140,7 @@ public class FiguraListDocs {
             add(name);
     }};
 
-    private enum ListDoc {
+    public enum ListDoc {
         KEYBINDS(() -> FiguraListDocs.KEYBINDS, "Keybinds", "keybinds", 2),
         PARENT_TYPES(() -> FiguraListDocs.PARENT_TYPES, "ParentTypes", "parent_types", 1),
         RENDER_TYPES(() -> FiguraListDocs.RENDER_TYPES, "RenderTypes", "render_types", 1),

--- a/common/src/main/java/org/figuramc/figura/model/rendering/PartFilterScheme.java
+++ b/common/src/main/java/org/figuramc/figura/model/rendering/PartFilterScheme.java
@@ -53,7 +53,7 @@ public enum PartFilterScheme {
      * the function is not called again on the children.
      */
     @FunctionalInterface
-    private interface SchemeFunction {
+    public interface SchemeFunction {
         Boolean test(ParentType typeOfThis, boolean previousSucceeded);
 
         static SchemeFunction onlyThisSeparate(ParentType typeToAllow) {


### PR DESCRIPTION
having these private actively hinder addon development, leading to some absolutely abhorrent code needed in addons to be able to add custom separate parent types, or to add to `/figura docs enums`
<sub>sillyplugin is currently using java's Unsafe to add to the latter :sob:</sub>

if there's a reason these are private, do let me know, because i can't think of one