### PR TITLE
bump Architectury Loom to 1.13 (was 1.6) + gradle 8.14.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,18 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Set up JDK 17
+#      - name: Set up JDK 17
+#        uses: actions/setup-java@v4
+#        with:
+#          distribution: 'temurin'
+#          java-version: 17
+#          check-latest: true
+
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
           check-latest: true
 
       - name: Build using Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id "architectury-plugin" version "3.4-SNAPSHOT"
-	id "dev.architectury.loom" version "1.6-SNAPSHOT" apply false
+	id "dev.architectury.loom" version "1.13-SNAPSHOT" apply false
 }
 
 architectury {

--- a/common/mojmap/build.gradle
+++ b/common/mojmap/build.gradle
@@ -23,8 +23,6 @@ task mojmapJar(type: RemapJarTask) {
 	inputFile = project(':common').remapJar.archiveFile
 	sourceNamespace = 'intermediary'
 	targetNamespace = 'named'
-	
-	remapperIsolation = true
 }
 
 task mojmapSourcesJar(type: RemapSourcesJarTask) {
@@ -36,8 +34,6 @@ task mojmapSourcesJar(type: RemapSourcesJarTask) {
 	inputFile = project(':common').sourcesJar.archiveFile
 	sourceNamespace = 'intermediary'
 	targetNamespace = 'named'
-	
-	remapperIsolation = true
 }
 
 build.dependsOn mojmapJar

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
1.14 is broken for obf MinecraftForge.
Can't make it to 1.17 without switching to Gradle 9, which breaks everything else.

You now need a JDK 21 to run Gradle.