### PR TITLE
Add limit to string.rep function

### DIFF
--- a/common/src/main/resources/assets/figura/scripts/sandbox.lua
+++ b/common/src/main/resources/assets/figura/scripts/sandbox.lua
@@ -11,7 +11,7 @@ collectgarbage = nil
 local _original_rep = string.rep
 string.rep = function(s, n, sep)
     if n > 10000000 then
-        error("string.rep: too many repetitions (" .. n .. " > 100000) If you're seeing this, Congrats. You can't crash with strings reaching GiBs in length", 3)
+        error("string.rep: too many repetitions (" .. n .. " > 10000000), 3)
     end
     return _original_rep(s, n, sep)
 end

--- a/common/src/main/resources/assets/figura/scripts/sandbox.lua
+++ b/common/src/main/resources/assets/figura/scripts/sandbox.lua
@@ -11,7 +11,7 @@ collectgarbage = nil
 local _original_rep = string.rep
 string.rep = function(s, n, sep)
     if n > 10000000 then
-        error("string.rep: too many repetitions (" .. n .. " > 10000000), 3)
+        error("string.rep: too many repetitions (" .. n .. " > 10000000"), 3)
     end
     return _original_rep(s, n, sep)
 end

--- a/common/src/main/resources/assets/figura/scripts/sandbox.lua
+++ b/common/src/main/resources/assets/figura/scripts/sandbox.lua
@@ -11,7 +11,7 @@ collectgarbage = nil
 local _original_rep = string.rep
 string.rep = function(s, n, sep)
     if n > 10000000 then
-        error("string.rep: too many repetitions (" .. n .. " > 10000000"), 3)
+        error("string.rep: too many repetitions (" .. n .. " > 10000000)", 3)
     end
     return _original_rep(s, n, sep)
 end

--- a/common/src/main/resources/assets/figura/scripts/sandbox.lua
+++ b/common/src/main/resources/assets/figura/scripts/sandbox.lua
@@ -8,5 +8,13 @@ dofile = nil
 loadfile = nil
 collectgarbage = nil
 
+local _original_rep = string.rep
+string.rep = function(s, n, sep)
+    if n > 10000000 then
+        error("string.rep: too many repetitions (" .. n .. " > 100000) If you're seeing this, Congrats. You can't crash with strings reaching GiBs in length", 3)
+    end
+    return _original_rep(s, n, sep)
+end
+
 -- GS easter egg
 _GS = _G


### PR DESCRIPTION
Prevent Memory Related Crashes from Stupidly long Repeating Strings.